### PR TITLE
Update Phoscon_Conbee_II.md with description plus corrected names

### DIFF
--- a/_zigbee/Phoscon_Conbee_II.md
+++ b/_zigbee/Phoscon_Conbee_II.md
@@ -1,8 +1,8 @@
 ---
 date_added: 2020-01-01
 model: BN-600107
-vendor: Dresden Elektronik
-title: Phoscon Conbee II Zigbee USB Gateway
+vendor: dresden elektronik
+title: ConBee II Zigbee USB Gateway
 category: coordinator
 supports: coordinator
 image: /assets/images/devices/Phoscon_ConbeeII.jpg
@@ -13,10 +13,17 @@ link: https://www.amazon.com/dp/B07PZ7ZHG5
 link2: https://www.reichelt.com/de/de/zigbee-usb-gateway-smart-home-deconz-ii-p260151.html
 link3: 
 ---
+ConBee II Zigbee USB Gateway is the second-generation Zigbee coordinator shield for Raspberry Pi, manufacturered and sold by dresden elektronik.
+
+Features a Zigbee Home Automation 1.2 (ZHA 1.2) coordinator firmware.
+
+Note! The first-gen ConBee adapter (as well as first-gen RaspBee) is no longer manufacturered as replaced by this ConBee II (and RaspBee II)
+
 Compatible with following Home Automation solutions:
+- [Home Assistant via its native ZHA integration component](https://www.home-assistant.io/integrations/zha/)
+- [Home Assistant via third-party deCONZ integration component](https://www.home-assistant.io/integrations/deconz/)
 - Jeedom via plugin "Deconz"
 - Domoticz via plugin "deCONZ"
-- Home Assistant via "deCONZ Component"
 - openHAB via "deCONZ Binding"
 - FHEM via "Hue Plugin"
 - Linux or Windows PC with the [free application of CONZ](https://phoscon.de/en/conbee2/install)


### PR DESCRIPTION
Update Phoscon_Conbee_II.md with description plus corrected their product and brand names:

ConBee product is written as "ConBee" with a capital "C" and capital "B". Also, dresden elektronik officially write their company name in all lower case letters, both in written text and in its logo.

* https://www.dresden-elektronik.com/contact.html

![dresden_elektronik_logo_small](https://user-images.githubusercontent.com/6320001/82022879-9f933000-968d-11ea-9084-ea4f859ebf90.png)

"Phoscon" is only dresden elektronik own Zigbee gateway software and is not really part of the "ConBee" or "RaspBee" product names. The only reason to include the name "Phoscon" is when specifically referring to using ConBee or RaspBee in their new Phoscon Gateway software package.

* https://www.dresden-elektronik.com/wireless/software/deconz.html**
* https://phoscon.de/en/conbee2/software

To be more precise, Phoscon Gateway is their names for their Linux based operating system distro for Raspberry Pi and it turns runs their deCONZ gateway software) or its Phoscon App for iOS and Android mobiles.

ConBee and Raspbee are also sold as stand-alone products withouth the Phoscon Gateway SW

* https://www.dresden-elektronik.com/product/raspbee-II.html
* https://www.dresden-elektronik.com/product/conbee-2.html
* https://www.dresden-elektronik.com/product/phoscon-gateway.html

That is why the products are listed on both sites:

* https://phoscon.de/en/raspbee2
* https://phoscon.de/en/conbee2
* https://phoscon.de/en/conbee
* https://phoscon.de/en/raspbee

Note that while not part of this PR, suggest that you should really rename those files to either only us their ConBee/RaspBee product names or named with "dresden_elektronik_productname" (so company name as prefix, just without with "Phoscon" as it has nothing to do with the ConBee or RaspBee product names:

 Phoscon_Conbee_II.md -> Conbee_II.md
 Phoscon_RaspBee.md -> RaspBee.md
 Phoscon_RaspBee_II.md -> RaspBee_II

or 

 Phoscon_Conbee_II.md -> dresden_elektronik_Conbee_II.md
 Phoscon_RaspBee.md -> dresden_elektronik_RaspBee.md
 Phoscon_RaspBee_II.md -> dresden_elektronik_RaspBee_II

Here is a picture of ConBee II product package which clearly does not show the name Phoscon:

![ConBee_II_product_package](https://user-images.githubusercontent.com/6320001/82023570-bf772380-968e-11ea-97fb-9c97c667deb7.png)
