### PR TITLE
Update LifeControl_MCLH-08.md

### DIFF
--- a/_zigbee/LifeControl_MCLH-08.md
+++ b/_zigbee/LifeControl_MCLH-08.md
@@ -4,10 +4,10 @@ model: MCLH-08
 vendor: LifeControl
 title: Air Quality Sensor
 category: sensor
-supports: voc, carbon monoxide, temperature, humidity
+supports: voc, carbon dioxide (eco2), temperature, humidity
 image: /assets/images/devices/LifeControl_MCLH-08.jpg
 zigbeemodel: ['VOC_Sensor']
-compatible: [deconz,z2m,iob]
+compatible: [deconz,z2m,iob, zigate]
 deconz: 
 mlink: https://lifecontrol.ru/devices/air-sensor/
 link: https://www.aliexpress.com/item/10000003080409.html


### PR DESCRIPTION
From our understand it is Carbon Dioxide and not monoxide.
Here is the link to the documentation: https://lifecontrol.ru/wp-content/uploads/2016/11/LifeControl_Air_Sensor_100x90_v4.pdf