### PR TITLE
Symfonisk works with Tasmota zbbridge

### DIFF
--- a/_zigbee/Ikea_E1744.md
+++ b/_zigbee/Ikea_E1744.md
@@ -6,7 +6,7 @@ category: remote
 supports: action, batterypct
 action: volume up, volume down, play, pause, skip forward, skip backward
 zigbeemodel: ['SYMFONISK Sound Controller']
-compatible: [z2m,zha,deconz,iob]
+compatible: [z2m,zha,deconz,iob,tasmota]
 mlink: https://www.ikea.com/us/en/p/symfonisk-sound-remote-white-20370482/
 link: https://www.amazon.com/IKEA-symfonisk-Sound-Remote-203-704-82/dp/B082W22BFC
 link2: https://www.amazon.com/IKEA-Symfonisk-Sound-Remote-104-338-47/dp/B082W1GV75


### PR DESCRIPTION
It generates messages like this:

One press:
```
tele/zbbridge/207F/SENSOR       {"0x207F":{"Device":"0x207F","0006!02":"","Power":2,"Endpoint":1,"LinkQuality":71}}
```

Two presses:
```
tele/zbbridge/207F/SENSOR       {"0x207F":{"Device":"0x207F","0008!02":"000100000000","DimmerStepUp":1,"Endpoint":1,"LinkQuality":71}}
```

Three presses:
```
tele/zbbridge/207F/SENSOR       {"0x207F":{"Device":"0x207F","0008!02":"010100000000","DimmerStepDown":1,"Endpoint":1,"LinkQuality":74}}
```

Rotate clockwise:
```
tele/zbbridge/207F/SENSOR       {"0x207F":{"Device":"0x207F","0008!01":"00C30000","DimmerMove":0,"Endpoint":1,"LinkQuality":68}}
tele/zbbridge/207F/SENSOR       {"0x207F":{"Device":"0x207F","0008!03":"0000","DimmerStop":true,"Endpoint":1,"LinkQuality":71}}
```

Rotate counter-clockwise:
```
tele/zbbridge/207F/SENSOR       {"0x207F":{"Device":"0x207F","0008!01":"01C30000","DimmerMove":1,"Endpoint":1,"LinkQuality":71}}
tele/zbbridge/207F/SENSOR       {"0x207F":{"Device":"0x207F","0008!03":"0000","DimmerStop":true,"Endpoint":1,"LinkQuality":68}}
```