### PR TITLE
Update Lonsonho_X711A.md

### DIFF
--- a/_zigbee/Lonsonho_X711A.md
+++ b/_zigbee/Lonsonho_X711A.md
@@ -5,10 +5,11 @@ vendor: Lonsonho
 title: No Neutral Push Button Light Switch 1 Gang
 category: switch
 supports: on/off
-zigbeemodel: ['TS0601']
+zigbeemodel: ['TS0601','TS0011']
 compatible: [z2m,iob,zha]
 mlink: 
 link: https://www.aliexpress.com/item/4000298926256.html
 link2: 
 link3: 
 ---
+It seems like there's two versions of this switch coming from AliExpress. The TS0011 appears to turn off by itself after two minutes after being paired for the first time with ZHA. To get it to function correctly after pairing the first time, press and hold the switch for 10s to enter pairing mode and then press 'Add Devices Via This Device' in your Zigbee Coordinator in Home Assistant. After that, it should function correctly.


### PR DESCRIPTION
After a ridiculous long time trying to figure out why this switch was just turning itself off after two minutes, it appears that after it's paired once, entering pair mode again and allowing it to join the network it's already joined (don't remove the device in HA) will get it to function correctly. I just want to help anyone who purchases this model from spending hours figuring this out!