### PR TITLE
Danfoss Ally TRV compatible with ZHA

### DIFF
--- a/_zigbee/Danfoss_014G2461.md
+++ b/_zigbee/Danfoss_014G2461.md
@@ -7,7 +7,7 @@ category: hvac
 mlink: https://www.smartheating.danfoss.com/
 link: 
 zigbeemodel: ['eTRV0100']
-compatible: [zigate,deconz]
+compatible: [zigate,deconz,zha]
 deconz: 2983
 ---
 


### PR DESCRIPTION
Confirming Danfoss Ally Zigbee 3.0 TRV. I paired it today with Home Assistant 0.117. 
Battery reports are OK, TRV responds to temperature changes in ZHA instantly.
<img width="1136" alt="Screenshot 2020-11-04 at 16 37 12" src="https://user-images.githubusercontent.com/6696872/98131862-fef32f80-1ebb-11eb-9765-fbe81c468d3f.png">
![IMG_5957](https://user-images.githubusercontent.com/6696872/98131904-0fa3a580-1ebc-11eb-80ff-a073c30462c4.jpg)


