### PR TITLE
Removing experimental

### DIFF
--- a/_zigbee/Sonoff_ZBBridge.md
+++ b/_zigbee/Sonoff_ZBBridge.md
@@ -12,7 +12,6 @@ link: https://www.itead.cc/sonoff-zbbridge.html
 link2: https://www.aliexpress.com/af/sonoff-zbbridge.html
 link3: https://www.banggood.com/SONOFF-ZBBridge-Smart-Bridge-p-1674754.html
 ---
-<h3>Support for this device is experimental!!!</h3>
 
 ## Flash ESP8266
 


### PR DESCRIPTION
ZBBridge is no longer experimental. We can drop this warning.