### PR TITLE
Added deconz

### DIFF
--- a/_zigbee/Xenon_SM-SO306.md
+++ b/_zigbee/Xenon_SM-SO306.md
@@ -7,7 +7,7 @@ category: plug
 supports: on/off
 zigbeemodel: ['TS0115']
 zb3: false
-compatible: [z2m]
+compatible: [z2m][deconz]
 mlink: http://www.xenon.cn/surge-protector100/sm-so306-e1/sm-so306-ez1.html
 link: https://www.aliexpress.com/item/4000356851943.html
 link2: https://www.aliexpress.com/item/4000981707898.html

--- a/_zigbee/Xenon_SM-SO306.md
+++ b/_zigbee/Xenon_SM-SO306.md
@@ -7,7 +7,7 @@ category: plug
 supports: on/off
 zigbeemodel: ['TS0115']
 zb3: false
-compatible: [z2m][deconz]
+compatible: [z2m,deconz]
 mlink: http://www.xenon.cn/surge-protector100/sm-so306-e1/sm-so306-ez1.html
 link: https://www.aliexpress.com/item/4000356851943.html
 link2: https://www.aliexpress.com/item/4000981707898.html


### PR DESCRIPTION
Got mine today from AliE https://www.aliexpress.com/item/4000981707898.html?spm=a2g0s.9042311.0.0.666c4c4duYx5ov
Works perfect with my ConBee 2.
Only ioBroker has an issue to find the plug, but that seems to be a problem of the Adapter, because HASS and the Phosbee App are able to identify and control all 5 (USB + 4 Plugs) entities. The 2 USB ports are controlled by a single entity, but that seems fair to me.