### PR TITLE
Change model number Rotary Dimmer Switch EU to EDM-1ZBA-EU

### DIFF
--- a/_zigbee/Earda_EDM-1ZAB-EU.md
+++ b/_zigbee/Earda_EDM-1ZAB-EU.md
@@ -1,6 +1,6 @@
 ---
 date_added: 2020-12-09
-model: EDM-1ZAB-EU
+model: EDM-1ZBA-EU
 vendor: Earda
 title: Rotary Dimmer Switch EU
 category: dimmer


### PR DESCRIPTION
I have bought this Rotary Dimmer Switch EU. I bought the one from the Haozee Official Store on Aliexpress (https://www.aliexpress.com/item/1005001704576003.html). The Model NO on the back says `EDM-1ZBA-EU` (**BA** not **AB**). I guess the original model number was wrong (from Alibaba) or there are actually two models of this switch?