### PR TITLE
Add battery problem description for Sonoff_SNZB-04

### DIFF
--- a/_zigbee/Sonoff_SNZB-04.md
+++ b/_zigbee/Sonoff_SNZB-04.md
@@ -16,3 +16,6 @@ link3: https://www.banggood.com/SONOFF-SNZB-04-ZB-Wireless-Door-or-Window-Sensor
 
 #### Pairing
 Long press reset button for 5s until the LED indicator flashes three times, which means the device has entered pairing mode
+
+Sometimes the battery is not mounted firmly which prevents the device from pairing properly.
+[Adding a washer between the battery holder](https://i.postimg.cc/SKkJmrpc/20210102-235846-1.jpg) and the battery or increasing the pressure on the holder fixes this.


### PR DESCRIPTION
The Sonoff_SNZB-04 has a problem where the battery is not mounted properly on some occasions (at least my two ones had the problem) which prevents them from being paired.
If you increase pressure on the holder or put something electroconductive like a washer between it and the battery it works properly.
This PR adds this workaround and problem depiction to the article.