### PR TITLE
add compatible coordinators

### DIFF
--- a/_zigbee/ZiGate-DIN.md
+++ b/_zigbee/ZiGate-DIN.md
@@ -7,7 +7,7 @@ category: coordinator
 supports: coordinator
 image: /assets/images/devices/ZiGate-DIN.jpg
 zigbeeid: none
-compatible: [zigate,zha]
+compatible: [zigate,zha,z2m]
 mlink: https://zigate.fr
 link: https://zigate.fr/produit/zigate-usb-din/
 link2: https://www.amazon.fr/Zigate-Passerelle-USB-avec-ZigBee/dp/B07Z6P9HX6/

--- a/_zigbee/ZiGate-DIN.md
+++ b/_zigbee/ZiGate-DIN.md
@@ -7,7 +7,7 @@ category: coordinator
 supports: coordinator
 image: /assets/images/devices/ZiGate-DIN.jpg
 zigbeeid: none
-compatible: [zigate,zha,z2m]
+compatible: [zigate,zha,z2m,iob]
 mlink: https://zigate.fr
 link: https://zigate.fr/produit/zigate-usb-din/
 link2: https://www.amazon.fr/Zigate-Passerelle-USB-avec-ZigBee/dp/B07Z6P9HX6/

--- a/_zigbee/ZiGate-FI.md
+++ b/_zigbee/ZiGate-FI.md
@@ -7,7 +7,7 @@ category: coordinator
 supports: coordinator
 image: /assets/images/devices/ZiGate-WIFI.jpg
 zigbeeid: none
-compatible: [zigate,zha]
+compatible: [zigate,zha,z2m]
 mlink: https://zigate.fr
 link: https://zigate.fr/produit/zigate-pack-wifi-v1-3/
 link2: https://shop.smarthome-europe.com/en/zigate/4316-zigate-universal-zigbee-gateway-wi-fi-3770014375025.html

--- a/_zigbee/ZiGate-FI.md
+++ b/_zigbee/ZiGate-FI.md
@@ -7,7 +7,7 @@ category: coordinator
 supports: coordinator
 image: /assets/images/devices/ZiGate-WIFI.jpg
 zigbeeid: none
-compatible: [zigate,zha,z2m]
+compatible: [zigate,zha,z2m,iob]
 mlink: https://zigate.fr
 link: https://zigate.fr/produit/zigate-pack-wifi-v1-3/
 link2: https://shop.smarthome-europe.com/en/zigate/4316-zigate-universal-zigbee-gateway-wi-fi-3770014375025.html

--- a/_zigbee/ZiGate-PiZiGate.md
+++ b/_zigbee/ZiGate-PiZiGate.md
@@ -7,7 +7,7 @@ category: coordinator
 supports: coordinator
 image: /assets/images/devices/ZiGate-PiZiGate.jpg
 zigbeeid: none
-compatible: [zigate,zha]
+compatible: [zigate,zha,z2m]
 mlink: https://zigate.fr
 link: https://zigate.fr/produit/pizigate-v1-0/
 link2: https://www.amazon.fr/Zigate-Module-avec-ZigBee-Raspberry/dp/B07Z6MQJWX

--- a/_zigbee/ZiGate-PiZiGate.md
+++ b/_zigbee/ZiGate-PiZiGate.md
@@ -7,7 +7,7 @@ category: coordinator
 supports: coordinator
 image: /assets/images/devices/ZiGate-PiZiGate.jpg
 zigbeeid: none
-compatible: [zigate,zha,z2m]
+compatible: [zigate,zha,z2m,iob]
 mlink: https://zigate.fr
 link: https://zigate.fr/produit/pizigate-v1-0/
 link2: https://www.amazon.fr/Zigate-Module-avec-ZigBee-Raspberry/dp/B07Z6MQJWX

--- a/_zigbee/ZiGate-USB.md
+++ b/_zigbee/ZiGate-USB.md
@@ -7,7 +7,7 @@ category: coordinator
 supports: coordinator
 image: /assets/images/devices/ZiGate-USB-TTL.jpg
 zigbeeid: none
-compatible: [zigate,zha,z2m]
+compatible: [zigate,zha,z2m,iob]
 mlink: https://zigate.fr
 link: https://zigate.fr/produit/zigate-ttl/
 link2: https://www.amazon.fr/Zigate-Passerelle-USB-avec-ZigBee/dp/B07Z6P9HX6/

--- a/_zigbee/ZiGate-USB.md
+++ b/_zigbee/ZiGate-USB.md
@@ -7,7 +7,7 @@ category: coordinator
 supports: coordinator
 image: /assets/images/devices/ZiGate-USB-TTL.jpg
 zigbeeid: none
-compatible: [zigate,zha]
+compatible: [zigate,zha,z2m]
 mlink: https://zigate.fr
 link: https://zigate.fr/produit/zigate-ttl/
 link2: https://www.amazon.fr/Zigate-Passerelle-USB-avec-ZigBee/dp/B07Z6P9HX6/

--- a/_zigbee/coordinator_CC2538+CC2592-PA.md
+++ b/_zigbee/coordinator_CC2538+CC2592-PA.md
@@ -7,7 +7,7 @@ category: coordinator
 supports: coordinator
 image: /assets/images/devices/coordinator_CC2538-CC2592-PA.jpg
 zigbeeid: none
-compatible: [iob,zha]
+compatible: [z2m,iob,zha]
 mlink: 
 link: https://www.aliexpress.com/item/4000714953897.html
 link2: https://www.amazon.com/CC2538-CC2592-Zigbee-Wireless-Module/dp/B06XPTR2ZY


### PR DESCRIPTION
Experimental support
https://www.zigbee2mqtt.io/information/supported_adapters.html and  https://github.com/Koenkk/zigbee-herdsman/issues/242

Need testers, We use this integration with such a chip on the Xiaomi gateway https://github.com/openlumi/xiaomi-gateway-openwrt . You can also add it to the list of supported coordinators with support for ZHA / z2m / zigate
