### PR TITLE
Confirmed deconz support for Orvibo W40CZ

### DIFF
--- a/_zigbee/Orvibo_W40CZ.md
+++ b/_zigbee/Orvibo_W40CZ.md
@@ -6,7 +6,7 @@ title: Smart Curtain Motor
 category: cover
 supports: open, close, stop, position
 zigbeemodel: ['093199ff04984948b4c78167c8e7f47e']
-compatible: [z2m]
+compatible: [z2m,deconz]
 mlink: https://www.orvibo.com/en/product/kaihe.html
 link: 
 link2: 


### PR DESCRIPTION
The device must be added as a light in deconz.

![image](https://user-images.githubusercontent.com/793611/105231210-33978e80-5b6f-11eb-9eba-5625d33f8cfb.png)
