### PR TITLE
Update GiovanniC_CC2538-CC2592.md

### DIFF
--- a/_zigbee/GiovanniC_CC2538-CC2592.md
+++ b/_zigbee/GiovanniC_CC2538-CC2592.md
@@ -8,7 +8,7 @@ supports: coordinator
 mlink: 
 link: https://www.tindie.com/products/GiovanniCas/cc2538-cc2592-zigbee-dongle-new-zb30/
 zigbeemodel: 
-compatible: [z2m]
+compatible: [z2m,ZHA]
 ---
 zigbee2matt compatible dongle with ZStack 3.0 firmware capable to handle more than 150 direct connected devices
 


### PR DESCRIPTION
All CC-253X is supported with or without AP chip.
https://github.com/zigpy/zigpy#experimental-support-for-additional-zigbee-radio-modules