### PR TITLE
Update GiovanniC_ZigbeePiHat.md

### DIFF
--- a/_zigbee/GiovanniC_ZigbeePiHat.md
+++ b/_zigbee/GiovanniC_ZigbeePiHat.md
@@ -7,6 +7,6 @@ category: coordinator
 mlink: 
 link: https://www.tindie.com/products/GiovanniCas/zigbee-hat-with-cc2538-for-raspberry/
 zigbeemodel: ZigeePiHat
-compatible: z2m
+compatible: [z2m,ZHA]
 ---
 Coordinator in HAT format using CC2538 chipset


### PR DESCRIPTION
All CC-253X is supported with or without AP chip.
https://github.com/zigpy/zigpy#experimental-support-for-additional-zigbee-radio-modules