### PR TITLE
Update GiovanniC_CC2530-CC2592.md

### DIFF
--- a/_zigbee/GiovanniC_CC2530-CC2592.md
+++ b/_zigbee/GiovanniC_CC2530-CC2592.md
@@ -4,10 +4,11 @@ model: Zigbee Dongle
 vendor: GiovanniC
 title: CC2530 + CC2592 - Zigbee dongle
 category: coordinator
+supports: router
 mlink: https://www.tindie.com/products/GiovanniCas/cc2530-cc2592-zigbee-dongle/
 link: https://www.tindie.com/products/GiovanniCas/cc2530-cc2592-zigbee-dongle/
 zigbeemodel: 0x00124b001ec8508c
-compatible: [z2m,ZHA]
+compatible: [z2m,zha]
 ---
 Coordinator working with zigbee2mqtt
 

--- a/_zigbee/GiovanniC_CC2530-CC2592.md
+++ b/_zigbee/GiovanniC_CC2530-CC2592.md
@@ -3,11 +3,11 @@ date_added: 2021-01-22
 model: Zigbee Dongle
 vendor: GiovanniC
 title: CC2530 + CC2592 - Zigbee dongle
-category: other
+category: coordinator
 mlink: https://www.tindie.com/products/GiovanniCas/cc2530-cc2592-zigbee-dongle/
 link: https://www.tindie.com/products/GiovanniCas/cc2530-cc2592-zigbee-dongle/
 zigbeemodel: 0x00124b001ec8508c
-compatible: z2m
+compatible: [z2m,ZHA]
 ---
 Coordinator working with zigbee2mqtt
 


### PR DESCRIPTION
I think the intention is that its one coordinator but can being used as one router. Therefore i think is better putting it the coordinator category (perhaps is possible having more categories but i have not seen one example tagging that) as the manufacturer is writing it is one coordinator in the link.