### PR TITLE
Tuya TYGWZ-01: Add extra line breaks in code blocks showing commands

### DIFF
--- a/_zigbee/Tuya_TYGWZ-01.md
+++ b/_zigbee/Tuya_TYGWZ-01.md
@@ -50,6 +50,7 @@ Connect the 3.3v to the gateway and start pressing ESC, you should see a prompt 
 
    ```
    FLR 80000000 401802 16
+
    DW 80000000 4
    ```
 
@@ -65,12 +66,14 @@ Connect the 3.3v to the gateway and start pressing ESC, you should see a prompt 
 
    ```
    FLR 80000000 402002 32
+
    DW 80000000 8
    ```
    Save the output of these commands, it should be something like:
 
    ```
    80000000:       110AAC2E        CC412394        5387DC8C        C98550E0
+   
    80000010:       7E64CE90        5795D7A9        4BA6FF51        8C2908E7
    ```
 
@@ -83,7 +86,7 @@ Run the script and input the output from the commands you ran above (making sure
 The script should then print your gateway's root password.
 
 ## Customise running software on the gateway
-### This section must be run on Linux or WSL
+### This section must be run on Linux or WSL (Or any Bash like shell)
 
 1. Download the serialgateway.bin from Paul's website here: [serialgateway.bin](https://paulbanks.org/download/files/lidl-zigbee/serialgateway.bin)
 
@@ -111,7 +114,7 @@ The script should then print your gateway's root password.
 5. The SSH port of the gateway will not be running on the standard 22 instead of 2333
 
 ## Upgrade the EZSP Version to 6.7.8.0
-### This section must be run on Linux or WSL
+### This section must be run on Linux or WSL (Or any Bash like shell)
 
 1. Download the firmware_upgrade.sh script from Github here: [firmware_upgrade.sh](https://github.com/Ordspilleren/lidl-gateway-freedom/blob/master/scripts/firmware_upgrade.sh) and the newer EZSP firmware from here: [NCP_UHW_MG1B232_678_PA0-PA1-PB11_PA5-PA4.gbl](https://github.com/grobasoz/zigbee-firmware/raw/master/EFR32%20Series%201/EFR32MG1B-256k/NCP/NCP_UHW_MG1B232_678_PA0-PA1-PB11_PA5-PA4.gbl)
 2. Make sure the script is executable with `chmod +x ./firmware_upgrade.sh`

--- a/_zigbee/Tuya_TYGWZ-01.md
+++ b/_zigbee/Tuya_TYGWZ-01.md
@@ -48,15 +48,14 @@ Connect the 3.3v to the gateway and start pressing ESC, you should see a prompt 
 
 1. Run the following commands in the terminal:
 
-   ```
+   ```bash
    FLR 80000000 401802 16
-
    DW 80000000 4
    ```
 
    Save the output of these commands, it should be something like: 
 
-   ```
+   ```bash
    80000000:       743B5638        6872576B        47694E69        233C2778
    ```
 
@@ -64,16 +63,14 @@ Connect the 3.3v to the gateway and start pressing ESC, you should see a prompt 
 
 2. Run the following commands in the terminal:
 
-   ```
+   ```bash
    FLR 80000000 402002 32
-
    DW 80000000 8
    ```
    Save the output of these commands, it should be something like:
 
-   ```
+   ```bash
    80000000:       110AAC2E        CC412394        5387DC8C        C98550E0
-   
    80000010:       7E64CE90        5795D7A9        4BA6FF51        8C2908E7
    ```
 


### PR DESCRIPTION
The parts of the document showing which commands to run in the bootloader should have line breaks but did not - I have added blank lines in between the two lines to (hopefully) amend this.

If there is a better way to ensure that:
\```
FLR 80000000 401802 16
DW 80000000 4
\```

renders properly without having to add a blank line I am happy to change this PR.