### PR TITLE
Add pairing notes for Busch-Jaeger 673x

### DIFF
--- a/_zigbee/Busch_Jaeger_6735.md
+++ b/_zigbee/Busch_Jaeger_6735.md
@@ -14,3 +14,8 @@ link3: https://www.amazon.se/dp/B017KXGJDG/
 ---
 "XX" in model number signifies multiple colors.
 
+### Paring
+
+1. If there are blinking LEDs wait until they don't blink anymore — the device is in some mode we don't want it to be.
+2. Press both buttons until the LEDs gleam permanently. They will blink alternately at first but keep the buttons pressed until really both lights are constantly illuminated. Then release the buttons. They LEDs should still glow.
+3. Now press both buttons again briefly. After about 1..2 seconds they will fade-glow; and your bridge should now instantly find it.

--- a/_zigbee/Busch_Jaeger_6736.md
+++ b/_zigbee/Busch_Jaeger_6736.md
@@ -14,3 +14,8 @@ link3: https://www.amazon.se/dp/B017KXGZVM/
 ---
 "XX" in model number signifies multiple colors.
 
+### Paring
+
+1. If there are blinking LEDs wait until they don't blink anymore — the device is in some mode we don't want it to be.
+2. Press both buttons of the top row until the LEDs gleam permanently. They will blink alternately at first but keep the buttons pressed until really both lights are constantly illuminated. Then release the buttons. They LEDs should still glow.
+3. Now press both buttons again briefly. After about 1..2 seconds they will fade-glow; and your bridge should now instantly find it.

--- a/_zigbee/Busch_Jaeger_6737.md
+++ b/_zigbee/Busch_Jaeger_6737.md
@@ -13,3 +13,9 @@ link2: https://www.amazon.co.uk/Busch-Jaeger-6737-815-Yellow-Wireless-Receiver-4
 link3: https://www.amazon.es/Busch-Jaeger-2CKA006730A0110-Busch-J-Bedienelement-edelstahl/dp/B017KXHFQQ
 ---
 "XX" in model number signifies multiple colors.
+
+### Paring
+
+1. If there are blinking LEDs wait until they don't blink anymore — the device is in some mode we don't want it to be.
+2. Press both buttons of the top row until the LEDs gleam permanently. They will blink alternately at first but keep the buttons pressed until really both lights are constantly illuminated. Then release the buttons. They LEDs should still glow.
+3. Now press both buttons again briefly. After about 1..2 seconds they will fade-glow; and your bridge should now instantly find it.


### PR DESCRIPTION
This adds a section about pairing the devices
particularly because the original manual reads
a bit awkward on this. This might be due to the
fact that the conceptualized the switches as
Routers.