### PR TITLE
Update Zen_Zen-01-W.md

### DIFF
--- a/_zigbee/Zen_Zen-01-W.md
+++ b/_zigbee/Zen_Zen-01-W.md
@@ -7,7 +7,7 @@ category: hvac
 supports: temperature, hvac
 image: /assets/images/devices/Zen-01-W.jpg
 zigbeemodel: ['Zen-01']
-compatible: [z2m,deconz]
+compatible: [z2m,deconz,zha]
 deconz: 1702
 mlink: https://zenecosystems.com/zenthermostat/
 link: https://www.amazon.com/Zen-Within-Zen-01-W-Thermostat-Edition/dp/B00XCVV8CS


### PR DESCRIPTION
I have the Zen-01 Zigbee thermostat working with the native ZHA integration so I decided to add zha to the compatibility list/table.
All modes (heat, cool, auto, off) are selectable/usable/operational.
Only the battery info is unknown/unavailable.