### PR TITLE
Add ZHA support for Hue Welcome Outdoor Floodlight

### DIFF
--- a/_zigbee/Philips_1743630P7.md
+++ b/_zigbee/Philips_1743630P7.md
@@ -7,7 +7,7 @@ category: light
 supports: on/off, brightness
 image: /assets/images/devices/Philips_1743630P7.jpg
 zigbeemodel: ['1743630P7', '1743630V7']
-compatible: [z2m,iob]
+compatible: [z2m,iob,zha]
 mlink: https://www2.meethue.com/en-gb/p/hue-white-welcome-outdoor-floodlight/1743630P7
 link: https://www.amazon.com/Philips-Hue-1743630V7-Welcome-Floodlight/dp/B07NDGBHTQ
 link2: https://www.amazon.de/dp/B07KMQ27FX


### PR DESCRIPTION
When updated to Philips Hue firmware version 1.74, this light can be found by ZHA and be added.