### PR TITLE
Update details for Lonsonho ZB-RGBCW bulb.

### DIFF
--- a/_zigbee/Lonsonho_ZB-RGBCW.md
+++ b/_zigbee/Lonsonho_ZB-RGBCW.md
@@ -1,13 +1,13 @@
 ---
 date_added: 2020-12-09
 model: ZB-RGBCW
-title: Tuya Zigbee 3.0 E27/B22 Bulb
+title: Tuya Zigbee 3.0 E27/B22/GU10 Bulb
 vendor: Lonsonho 
 category: light
 type: bulb
 supports: on/off, brightness, colortemp, colorxy
 mlink: 
 link: https://www.aliexpress.com/item/4001242163772.html
-zigbeemodel: ['ZB-RGBCW','ZB-CL01']
+zigbeemodel: ['ZB-RGBCW','ZB-CL01','ZB-CL02']
 compatible: [z2m,zha]
 ---


### PR DESCRIPTION
Update details based upon adding support for ZB-CL02 bulb to zigbee2mqtt, see: https://github.com/Koenkk/zigbee-herdsman-converters/pull/2675