### PR TITLE
Update Moes_BRT-100.md

### DIFF
--- a/_zigbee/Moes_BRT-100.md
+++ b/_zigbee/Moes_BRT-100.md
@@ -6,7 +6,7 @@ title: Thermostatic Radiator Valve
 zigbeemodel: ['TS0601','_TZE200_b6wax7g0']
 category: hvac
 supports: thermostat, temperature, battery, window detection, child lock
-compatible: [z2m]
+compatible: [z2m,zha]
 z2m: BRT-100-TRV 
 mlink: https://expo.tuya.com/product/829080
 link: https://www.aliexpress.com/item/1005002433574444.html


### PR DESCRIPTION
Its in dev and going in the next ZHA release https://github.com/home-assistant/core/pull/52065
The name that is given is miss leading if looking on the manufacture home page [Moes ZTRV-BY-100-WH-EE](https://www.moeshouse.com/collections/trv-radiator-valve/products/tuya-zigbee3-0-new-mini-radiator-actuator-valve-smart-programmable-thermostat-temperature-controller) but i letting  it for other to taking the fight (as the Z2M naming the IKEA E2001 with manufacturing year and week and not the real model name)