### PR TITLE
Add zha compatibility for Ewelink ZB-SW01 and ZB-SW02

### DIFF
--- a/_zigbee/eWeLink_ZB-SW01.md
+++ b/_zigbee/eWeLink_ZB-SW01.md
@@ -6,7 +6,7 @@ title: Light Switch 1 Gang
 category: switch
 supports: on/off
 zigbeemodel: ['ZB-SW01']
-compatible: [z2m]
+compatible: [z2m,zha]
 mlink: 
 link: https://www.aliexpress.com/item/1005001291853225.html
 link2: https://www.chytrevypinace.cz/Tlacitkovy-ZigBee-vypinac-1CH-d209.htm

--- a/_zigbee/eWeLink_ZB-SW02.md
+++ b/_zigbee/eWeLink_ZB-SW02.md
@@ -6,7 +6,7 @@ title: Light Switch 2 Gang
 category: switch
 supports: on/off
 zigbeemodel: ['ZB-SW02', 'E220-KR2N0Z0-HA']
-compatible: [z2m,tasmota]
+compatible: [z2m,tasmota,zha]
 mlink: 
 link: https://www.aliexpress.com/item/1005001291467678.html
 link2: https://www.chytrevypinace.cz/Tlacitkovy-ZigBee-vypinac-2CH-d210.htm


### PR DESCRIPTION
I have both of them working in my house flawlessly with zha in home assistant since at least version 2021.5.0