### PR TITLE
Correct compatibility overview

### DIFF
--- a/_zigbee/Neo_NAS-TH02B.md
+++ b/_zigbee/Neo_NAS-TH02B.md
@@ -8,7 +8,7 @@ type: [temperature sensor, humidity sensor, illumination sensor]
 supports: temperature, humidity, illumination, battery
 zigbeemodel: ['TS0201','_TZ3000_qaaysllp']
 zb3: true
-compatible: [zha]
+compatible: [deconz]
 mlink: 
 link: https://www.aliexpress.com/item/1005002384720598.html
 link2: 


### PR DESCRIPTION
The only entities added to Home Assistant when using ZHA are battery and illuminance. However, adding it via deconz adds at least humidity, illuminance and temperature (battery missing).