### PR TITLE
ZHA supports Hive Heating Thermostat Remote Control and the Hive Single Channel Receiver

### DIFF
--- a/_zigbee/Hive_SLR1b.md
+++ b/_zigbee/Hive_SLR1b.md
@@ -14,3 +14,18 @@ link:
 link2: 
 link3: 
 ---
+
+## Pairing instructions
+
+1. Remove the thermostat from the wall and remove a battery
+2. Turn boiler off at the mains, this will also turn off the receiver.
+3. Turn the boiler on
+4. Hold down central heating button on the Hive receiver until light turns pink, then release
+5. Hold down the central heating button again until the light turns amber with double flashing
+6. Pair with Home Assistant - using ZHA’s ‘add device’
+7. At this point the amber double flash may change to a single flash
+8. Stop ZHA from searching for devices by pressing back
+9. Replace the battery in the thermostat and allow to boot
+10. Press and hold the menu and back buttons, allow the countdown to finish and release when you see 'welcome' - after selecting - a language, it will enter pairing mode.
+11. On ZHA select the Hive receiver device you added earlier, now click “ADD DEVICES VIA THIS DEVICE”
+12. The thermostat should now pair to the boiler receiver. The amber light should turn green.

--- a/_zigbee/Hive_SLR1b.md
+++ b/_zigbee/Hive_SLR1b.md
@@ -7,7 +7,7 @@ category: hvac
 supports: thermostat, occupied heating, weekly schedule
 image: /assets/images/devices/Hive_SLR1b.jpg
 zigbeemodel: ['SLR1b']
-compatible: [z2m,deconz]
+compatible: [zha,z2m,deconz]
 deconz: 3090
 mlink: https://www.hivehome.com/bg/products/hive-active-heating?cid=cen.bg..heat_HAH
 link: 

--- a/_zigbee/Hive_SLT3.md
+++ b/_zigbee/Hive_SLT3.md
@@ -6,7 +6,7 @@ title: Heating Thermostat Remote Control
 category: hvac
 supports: communicate via thermostat
 zigbeemodel: ['SLT3','SLT3B']
-compatible: [z2m]
+compatible: [zha,z2m]
 mlink: https://www.hivehome.com/products/hive-active-heating
 link: https://www.amazon.co.uk/dp/B011B3J6KY
 link2: 

--- a/_zigbee/Hive_SLT3.md
+++ b/_zigbee/Hive_SLT3.md
@@ -12,3 +12,17 @@ link: https://www.amazon.co.uk/dp/B011B3J6KY
 link2: 
 link3: 
 ---
+## Pairing instructions
+
+1. Remove the thermostat from the wall and remove a battery
+2. Turn boiler off at the mains, this will also turn off the receiver.
+3. Turn the boiler on
+4. Hold down central heating button on the Hive receiver until light turns pink, then release
+5. Hold down the central heating button again until the light turns amber with double flashing
+6. Pair with Home Assistant - using ZHA’s ‘add device’
+7. At this point the amber double flash may change to a single flash
+8. Stop ZHA from searching for devices by pressing back
+9. Replace the battery in the thermostat and allow to boot
+10. Press and hold the menu and back buttons, allow the countdown to finish and release when you see 'welcome' - after selecting - a language, it will enter pairing mode.
+11. On ZHA select the Hive receiver device you added earlier, now click “ADD DEVICES VIA THIS DEVICE”
+12. The thermostat should now pair to the boiler receiver. The amber light should turn green.


### PR DESCRIPTION
https://community.home-assistant.io/t/can-i-integrate-hive-active-heating-into-ha-without-the-hive-hub/246728/17

Pairing instructions for the  Hive Heating Thermostat Remote Control and the Hive Single Channel Receiver (not sure where to add these in the PR)

- Remove the thermostat from the wall and remove a battery
- Turn boiler off at the mains, this will also turn off the receiver.
- Turn the boiler on
- Hold down central heating button on the Hive receiver until light turns pink, then release
- Hold down the central heating button again until the light turns amber with double flashing
- Pair with Home Assistant - using ZHA’s ‘add device’
- At this point the amber double flash may change to a single flash
- Stop ZHA from searching for devices by pressing back
- Replace the battery in the thermostat and allow to boot
- Press and hold the menu and back buttons, allow the countdown to finish and release when you see 'welcome' - after selecting - a language, it will enter pairing mode.
- On ZHA select the Hive receiver device you added earlier, now click “ADD DEVICES VIA THIS DEVICE”
- The thermostat should now pair to the boiler receiver. The amber light should turn green.
