### PR TITLE
Correct manufacturer link (previous was to GL-SD-001)

### DIFF
--- a/_zigbee/Gledopto_GL-SD-002.md
+++ b/_zigbee/Gledopto_GL-SD-002.md
@@ -7,7 +7,7 @@ category: switch
 supports: on/off
 zigbeemodel: ['GL-SD-002']
 compatible: []
-mlink: http://www.gledopto.com/h-col-380.html
+mlink: https://www.gledopto.com/h-col-391.html
 link: https://www.aliexpress.com/item/1005003210832638.html
 link2: https://www.banggood.com/Gledopto-Tuya-Zigbee3_0-AC110-240V-Smart-Dimmer-Switch-Module-Relay-No-Neutral-Wire-Works-with-Alexa-Google-Home-p-1890395.html
 ---


### PR DESCRIPTION
Correct manufacturer link for 

Gledopto Switch Module | GL-SD-002

Previous one directed to page of GL-SD-001.