### PR TITLE
How to pair with recent firmware

### DIFF
--- a/_zigbee/Legrand_067773.md
+++ b/_zigbee/Legrand_067773.md
@@ -7,7 +7,7 @@ category: switch
 supports: action
 image: /assets/images/devices/Legrand_067773.jpg
 zigbeemodel: [' Remote switch']
-compatible: [z2m,zigate,deconz]
+compatible: [z2m,zigate,deconz,ZHA]
 zigate: https://zigate.fr/le-materiel-compatible-zigate/compatible/commandesansfilpourclairagepriseconnecteoumicromoduleclianenetatmo
 mlink: https://www.legrand.fr/pro/catalogue/42559-version-celiane-with-netatmo/commande-sans-fil-celiane-with-netatmo-pour-eclairage-ou-prise-connectee-ou-micromodule-titane
 link: https://www.amazon.fr/dp/B07G4JY35D

--- a/_zigbee/Legrand_067773.md
+++ b/_zigbee/Legrand_067773.md
@@ -7,7 +7,7 @@ category: switch
 supports: action
 image: /assets/images/devices/Legrand_067773.jpg
 zigbeemodel: [' Remote switch']
-compatible: [z2m,zigate,deconz,ZHA]
+compatible: [z2m,zigate,deconz,zha]
 zigate: https://zigate.fr/le-materiel-compatible-zigate/compatible/commandesansfilpourclairagepriseconnecteoumicromoduleclianenetatmo
 mlink: https://www.legrand.fr/pro/catalogue/42559-version-celiane-with-netatmo/commande-sans-fil-celiane-with-netatmo-pour-eclairage-ou-prise-connectee-ou-micromodule-titane
 link: https://www.amazon.fr/dp/B07G4JY35D


### PR DESCRIPTION
Recently Legrand added capability to easily pair its devices with third-party coordinators. 

Here is a procedure to pair (take from here https://developer.legrand.com/forums/topic/how-to-change-zigbee-channel-for-ref-067773-2)

When you reset the device, it will scan the 16 possible channels (feature available starting NLT-50 firmware). If a network is opened - and if your gateway accepts it -, your device will log on it. If several channels are opened, it could be difficult to detect the correct one. The best is (if possible) not to open several networks, or to use a software with a programing console to choose a specific channel

I have successfully paired my device with ZHA.

To update firmware Legrand coordinator is need. The procedure is described here: https://developer.legrand.com/forums/topic/wireless-switches-not-updating/