### PR TITLE
Added ZHA compatibility with Vimar IoT switch

### DIFF
--- a/_zigbee/Vimar_14592_16492_19592_20592.md
+++ b/_zigbee/Vimar_14592_16492_19592_20592.md
@@ -6,7 +6,7 @@ title: 2-way Switch IoT Connected Mechanism
 category: switch
 supports: on/off
 zigbeemodel: ['2_Way_Switch_v1.0', 'On_Off_Switch_v1.0']
-compatible: [z2m]
+compatible: [z2m,zha]
 z2m: 14592.0
 mlink: https://www.vimar.com/en/int/catalog/product/index/code/14592.0
 link: 


### PR DESCRIPTION
I can confirm the compatibility of this switch with ZHA. You don't need the Vimar hub to use it (the connection type can be changed to Zigbee without having a Vimar hub).