### PR TITLE
Inconsistent key name

### DIFF
--- a/_zigbee/Philips_LWB014.md
+++ b/_zigbee/Philips_LWB014.md
@@ -5,7 +5,7 @@ title: Hue White A19 E26
 category: light
 supports: on/off, brightness
 image: /assets/images/devices/Philips_LWB014.jpg
-zigbeeModel: ['LWB014']
+zigbeemodel: ['LWB014']
 compatible: [z2m,deconz,zigate,zha]
 mlink: https://www2.meethue.com/es-cl/p/hue-white-ampolleta-individual-e27/8718696449578
 link: https://www.amazon.com/Philips-Hue-Equivalent-Dimmable-Assistant/dp/B073SSNNNH


### PR DESCRIPTION
Since 1813 other devices has lowercase "zigbeemodel", I assume this to be the canonical form