### PR TITLE
Key consistency

### DIFF
--- a/_zigbee/EDP_re-dy_plug.md
+++ b/_zigbee/EDP_re-dy_plug.md
@@ -5,7 +5,7 @@ vendor: EDP
 title: re:dy plug A/C
 category: plug
 supports: on/off, power measurement
-manufacturername: ['EDP-WITHUS']
+manufacturer: ['EDP-WITHUS']
 zigbeemodel: ['ZB-SmartPlug-1.0.0']
 compatible: [z2m,iob,zha,deconz]
 deconz: 3959


### PR DESCRIPTION
Since 7 other devices have key "manufacturer", I assume this to he the canonical form. Of course, up to 8 is still not very common...