### PR TITLE
Include ZHA support for WHD02 (Mini Smart Switch)

### DIFF
--- a/_zigbee/Tuya_WHD02.md
+++ b/_zigbee/Tuya_WHD02.md
@@ -6,7 +6,7 @@ title: Mini Smart Switch 10A/16A
 category: switch
 supports: on/off
 zigbeemodel: ['TS0001', '_TZ3000_hktqahrq','TS000F','_TZ3000_m9af2l6g']
-compatible: [z2m]
+compatible: [zha,z2m]
 z2m: TS0121_plug
 mlink: 
 link: https://www.aliexpress.com/item/1005002716718315.html


### PR DESCRIPTION
Tested and working without problems as a router on Hass 2021.11.4 using a "Slae.sh cc2652rb stick" as ZHA coordinator.