### PR TITLE
Add ZHA to Hive SLR2 support

### DIFF
--- a/_zigbee/Hive_SLR2.md
+++ b/_zigbee/Hive_SLR2.md
@@ -4,9 +4,9 @@ model: SLR2
 vendor: Hive
 title: Heating Thermostat Dual Channel Receiver
 category: hvac
-supports: communicate via thermostat
+supports: communicate via thermostat, thermostat
 zigbeemodel: ['SLR2']
-compatible: [deconz,z2m]
+compatible: [deconz,z2m,zha]
 deconz: 2978
 mlink: 
 link: 


### PR DESCRIPTION
~~Hive SLR2 works under ZHA AFTER HASS 2022.2.x (Due 2nd Feb 2022, Marked as draft due to this)~~

Might be worth looking at "communicate via thermostat" should be on here as something it "supports" -- I assume this means the unit Hive ships with these, SLT2, works to control it?