### PR TITLE
Update Lidl_HG07834C.md

### DIFF
--- a/_zigbee/Lidl_HG07834C.md
+++ b/_zigbee/Lidl_HG07834C.md
@@ -2,11 +2,11 @@
 date_added: 2021-11-10
 model: HG07834C
 vendor: Lidl
-title: Livarno Lux E27 6,5W RGB Bulb
+title: Livarno Lux E27 9W RGB Bulb
 category: light
 type: bulb
 supports: on/off, brightness, colortemp, colorxy
-zigbeemodel: ['TS0505A','_TZ3000_qd7hej8u']
+zigbeemodel: ['TS0505A', 'TS0505B','_TZ3000_qd7hej8u']
 compatible: [z2m,deconz,zha,iob, z4d]
 deconz: 3975
 mlink: https://www.lidl.com/


### PR DESCRIPTION
E27 is 9W

Model purchased today identified as `TS0505B` in zha after adoption, unsure if there's any difference, `HG07834C` is still what is printed on the bulb.