### PR TITLE
Eurotronic_SPZB0001: Fix Broken Link

### DIFF
--- a/_zigbee/Eurotronic_SPZB0001.md
+++ b/_zigbee/Eurotronic_SPZB0001.md
@@ -55,4 +55,4 @@ ZbSend {"Device":"<device>","Manuf":"0x1037","Write":{"EurotronicHostFlags":1}}
 ### Known Problems
 
 Under some circumstances, there are known problems with writing the Temperature Set Point to the Device. 
-A discussion regarding the issues is available under (https://github.com/EUROTRONIC-Technology/Spirit-ZigBee/issues/1)[https://github.com/EUROTRONIC-Technology/Spirit-ZigBee/issues/1]
+A discussion regarding the issues is available under [https://github.com/EUROTRONIC-Technology/Spirit-ZigBee/issues/1](https://github.com/EUROTRONIC-Technology/Spirit-ZigBee/issues/1)


### PR DESCRIPTION
Unfortunately, in the earlier PR the Markdown Syntax got mixed up. This PR fixes that issue.