### PR TITLE
Add DECONZ to the compatibility list of DLKZMK12LM

### DIFF
--- a/_zigbee/Aqara_DLKZMK12LM.md
+++ b/_zigbee/Aqara_DLKZMK12LM.md
@@ -6,7 +6,7 @@ title: Single Switch Module T1 (No Neutral)
 category: switch
 supports: on/off, power measurement, device temperature, power outage memory
 zigbeemodel: ['lumi.switch.l0acn1']
-compatible: [z2m,tasmota]
+compatible: [z2m,deconz,tasmota]
 mlink: https://www.aqara.com/cn/productDetail/d15
 link: https://www.aliexpress.com/item/1005003307390282.html
 link2: https://www.aliexpress.com/item/1005003159290708.html


### PR DESCRIPTION
Aqara Single Switch Module T1 (No Neutral), model DLKZMK12LM is compatible with DECONZ using a Conbee II. I have it paired and working flawlessly since three weeks ago.

>Note: In my case it only supports on/off. No device temperature, power measurement or power outage memory.