### PR TITLE
Update Third_Reality_3RSP019BZ.md

### DIFF
--- a/_zigbee/Third_Reality_3RSP019BZ.md
+++ b/_zigbee/Third_Reality_3RSP019BZ.md
@@ -6,7 +6,7 @@ title: BLE 15A Smart Plug
 category: plug
 supports: on/off, 
 zigbeemodel: ['3RSP019BZ']
-compatible: [z2m]
+compatible: [z2m, zha]
 mlink: 
 link: https://www.amazon.com/dp/B09CP9PL42
 link2: 


### PR DESCRIPTION
This device is working in ZHA in HA version 2022.4.6.  When you plug it in, it immediately enters paring mode.  This device paired with ZHA faster than any of my SONOFF devices.