### PR TITLE
Update Aqara_ZNJLBL01LM.md

### DIFF
--- a/_zigbee/Aqara_ZNJLBL01LM.md
+++ b/_zigbee/Aqara_ZNJLBL01LM.md
@@ -5,7 +5,7 @@ vendor: Aqara
 title: Roller Shade Driver E1
 category: cover
 type: curtain motor
-supports: cover position, battery
+supports: cover position, battery, device temperature
 zigbeemodel: ['lumi.curtain.acn002']
 compatible: [z2m, deconz, zha]
 deconz: 5330


### PR DESCRIPTION
Added device temperature as support. Also, could be of interest to mention in the notes that latest firmware of HA and the zigbee coordinator is needed for it to work. Older versions of firmware have an issue with quirks, so the device cannot be controlled thorugh ZHA. I am running Conbee II stick with firmware released 2021 aug 19, and HA 2022.05.1 and it works as intended.