### PR TITLE
Update OWON_THS317-ET.md

### DIFF
--- a/_zigbee/OWON_THS317-ET.md
+++ b/_zigbee/OWON_THS317-ET.md
@@ -2,11 +2,11 @@
 date_added: 2022-01-21
 model: THS317-ET
 vendor: OWON
-title: Temperature and Humidity Sensor with Probe
+title: Temperature Sensor with Probe
 category: sensor
-supports: temperature, humidity, battery
+supports: temperature, battery
 zigbeemodel: ['THS317-ET', 'TS317']
-compatible: [z2m, z4d, deconz]
+compatible: [z2m, z4d, deconz, zha]
 deconz: 5777
 mlink: https://www.owon-smart.com/zigbee-temperature-sensor-with-probe-ths-317-et-product/
 link: https://www.alibaba.com/product-detail/Mini-Smart-Home-Security-Zigbee-Temperature_1600183672978.html


### PR DESCRIPTION
I have tested this sensor THS317-ET with zha. According to me and to the documentation it is only a temperature sensor and no humidity sensor. Only the standard model without the external probe has temp and hum. I have binded it to zha and is was discovered correctly. It seems 100% compatible with zha.