### PR TITLE
Update Eglo_99106.md

### DIFF
--- a/_zigbee/Eglo_99106.md
+++ b/_zigbee/Eglo_99106.md
@@ -1,7 +1,6 @@
 ---
 date_added: 2022-07-10
 model: 99106
-vendor: EGLO
 title: Connect-Z IP44 Motion Sensor
 vendor: Eglo
 category: sensor


### PR DESCRIPTION
Duplicate "vendor" key. Since other Eglo devices use the value "Eglo", the "EGLO" line was removed