### PR TITLE
LoraTap SS600ZB alternative pairing method

### DIFF
--- a/_zigbee/LoraTap_SS600ZB.md
+++ b/_zigbee/LoraTap_SS600ZB.md
@@ -15,3 +15,8 @@ link2: https://www.domadoo.fr/en/peripheriques/5712-loratap-telecommande-zigbee-
 
 ## Pairing
 To pair the device, open it with a screwdriver and press the pairing button for 5 seconds until the yellow indicator light flashes.
+
+## Pairing (Alternative Method)
+To pair the device, press and hold any of the buttons for 10 seconds until the yellow indicator light flashes.
+
+The model which I received required a double-inclusion - when first added, ZHA said the device was configured but the buttons did not trigger events and the yellow indicator light continued to flash. In this case, open the switch, remove and replace the battery and pair the device a second time.

--- a/_zigbee/LoraTap_SS600ZB.md
+++ b/_zigbee/LoraTap_SS600ZB.md
@@ -11,10 +11,8 @@ compatible: [z2m, iob, tasmota, zha, z4d, deconz]
 mlink: https://www.loratap.com/products/ss600zb
 link: https://www.aliexpress.com/item/1005001298730723.html
 link2: https://www.domadoo.fr/en/peripheriques/5712-loratap-telecommande-zigbee-3-boutons.html
+pairing: "To pair the device, open it with a screwdriver and press the pairing button for 5 seconds until the yellow indicator light flashes."
 ---
-
-## Pairing
-To pair the device, open it with a screwdriver and press the pairing button for 5 seconds until the yellow indicator light flashes.
 
 ## Pairing (Alternative Method)
 To pair the device, press and hold any of the buttons for 10 seconds until the yellow indicator light flashes.


### PR DESCRIPTION
Add alternative pairing method for models which don't have a pairing button.