### PR TITLE
Adds ZHA support (tested & working)

### DIFF
--- a/_zigbee/GE_45852GE.md
+++ b/_zigbee/GE_45852GE.md
@@ -6,7 +6,7 @@ category: dimmer
 supports: brightness
 image: /assets/images/devices/GE_45852GE.jpg
 zigbeemodel: ['45852']
-compatible: [z2m,iob]
+compatible: [z2m,zha,iob]
 mlink: https://www.smartthings.com/products/ge-plug-in-smart-dimmer-zigbee
 link: https://www.amazon.com/GE-Wireless-compatible-Monitoring-45852GE/dp/B019G6RQCS
 link2: 

--- a/_zigbee/Innr_AE_260.md
+++ b/_zigbee/Innr_AE_260.md
@@ -6,7 +6,7 @@ title: Dimmable White Bulb E26
 category: bulb
 supports: brightness
 zigbeemodel: ['AE 260']
-compatible: [z2m]
+compatible: [z2m,zha]
 mlink: 
 link: https://www.amazon.com/Philips-SmartThings-Required-Dimmable-Equivalent/dp/B07RYVW9SD
 link2: 

--- a/_zigbee/Innr_BE_220.md
+++ b/_zigbee/Innr_BE_220.md
@@ -7,7 +7,7 @@ category: bulb
 type: Bulb
 supports: brightness
 zigbeemodel: ['BE 220']
-compatible: [z2m]
+compatible: [z2m,zha]
 mlink: 
 link: https://www.amazon.com/dp/B07SD8SGZT
 link2: 

--- a/_zigbee/Philips_LTA003.md
+++ b/_zigbee/Philips_LTA003.md
@@ -5,7 +5,7 @@ title: Hue White Ambiance A19 E26 Bluetooth
 category: bulb
 supports: brightness, colortemp
 zigbeemodel: ['LTA003']
-compatible: [z2m]
+compatible: [z2m,zha]
 mlink: 
 link: 
 link2: 

--- a/_zigbee/Philips_LWA003.md
+++ b/_zigbee/Philips_LWA003.md
@@ -5,7 +5,7 @@ title: Hue White A19 E26 Bluetooth
 category: bulb
 supports: brightness
 zigbeemodel: ['LWA003']
-compatible: [z2m]
+compatible: [z2m,zha]
 z2m: 9290022268
 mlink: https://www2.meethue.com/en-us/p/hue-white-1-pack-e26/046677476861
 link: https://www.amazon.com/Philips-Hue-Bluetooth-compatible-Assistant/dp/B07QV9XLTK

--- a/_zigbee/Philips_LWB015.md
+++ b/_zigbee/Philips_LWB015.md
@@ -7,7 +7,7 @@ category: bulb
 supports: brightness
 image: /assets/images/devices/Philips_LWB015.jpg
 zigbeemodel: ['LWB015']
-compatible: [z2m]
+compatible: [z2m,zha]
 mlink: https://www2.meethue.com/en-us/p/hue-white-single-par38-outdoor/046677476816
 link: https://www.amazon.com/Philips-Outdoor-Hue-PAR-38-476820/dp/B07D9XL641
 link2: https://www.amazon.ca/Philips-Compatible-Amazon-Google-Assistant/dp/B07DBMBCVK/

--- a/_zigbee/Philips_LWV002.md
+++ b/_zigbee/Philips_LWV002.md
@@ -7,7 +7,7 @@ category: bulb
 supports: brightness
 image: /assets/images/devices/Philips_046677551780.jpg
 zigbeemodel: ['LWV002']
-compatible: [z2m]
+compatible: [z2m,zha]
 mlink: https://www2.meethue.com/en-us/p/hue-white-1-pack-st19-e26-filament-edison/046677551780
 link: https://www.amazon.com/Philips-Hue-Bluetooth-compatible-activated/dp/B07VRF9NWK
 link2: https://www.amazon.ca/PHILIPS-551820-White-Filament-ST19/dp/B081BLN9W1


### PR DESCRIPTION
Adds ZHA support for the following devices:

- GE Plug-in Smart Dimmer (45852GE)
- Innr Dimmable White Bulb E26 (AE_260)
- Innr Dimmable Warm White BR30 E26 Bulb (BE_220)
- Philips Hue White Ambiance A19 E26 Bluetooth (LTA003)
- Philips Hue White A19 E26 Bluetooth (LWA003)
- Philips Hue White PAR38 Outdoor (LWB015)
- Philips Hue Single Filament Bulb ST19 E26 (LWV002)

Tested various device functions and confirms pairs successfully with Conbee II and SkyConnect coordinators.