### PR TITLE
Update pairing instruction for Legrand (Wiki URL)

### DIFF
--- a/_includes/pairing.html
+++ b/_includes/pairing.html
@@ -65,7 +65,7 @@ Some Legrand devices work only on Zigbee channel 11. With certain devices you ne
 <li>Press the reset button 8s (approximately) to start the pairing procedure
 <li>Make successive clicks on the reset button (every second), until the LED turns green
 <p>
-Detailed pairing instructions and additional information on <a href="https://github.com/pipiche38/Domoticz-Zigate-Wiki/blob/master/en-eng/Legrand-Netatmo-corner.md" target="_blank">pipiche38 wiki</a>.
+Detailed pairing instructions and additional information on <a href="https://github.com/zigbeefordomoticz/wiki/blob/master/en-eng/Corner_Legrand-Netatmo.md" target="_blank">pipiche38 wiki</a>.
 </p>
 {%- elsif page.vendor contains "Konke" -%}
 


### PR DESCRIPTION
fix the URL of the Wiki > https://github.com/zigbeefordomoticz/wiki/blob/master/en-eng/Corner_Legrand-Netatmo.md instead of https://github.com/pipiche38/Domoticz-Zigate-Wiki/blob/master/en-eng/Legrand-Netatmo-corner.md