### PR TITLE
Update Villeroy_Boch_C5850000.md

### DIFF
--- a/_zigbee/Villeroy_Boch_C5850000.md
+++ b/_zigbee/Villeroy_Boch_C5850000.md
@@ -5,7 +5,7 @@ vendor: Villeroy & Boch
 title: Subway 3.0 ZigBee Home Automation Kit for vanity unit
 category: light
 zigbeemodel: ['5991711', '5991713']
-compatible: [z2m] [zha]
+compatible: [z2m, zha]
 mlink: https://www.villeroy-boch.co.uk/bathroom-and-wellness/products/Subway-3.0-ZigBeeR-Home-Automation-Kit-for-vanity-unit-Rectangle-C5850000.html
 link: https://www.skybad.de/en/villeroy-und-boch-subway-3-0-modul-c5850000-fuer-unterschraenke-funkstandard.html
 ---

--- a/_zigbee/Villeroy_Boch_C5850000.md
+++ b/_zigbee/Villeroy_Boch_C5850000.md
@@ -5,7 +5,7 @@ vendor: Villeroy & Boch
 title: Subway 3.0 ZigBee Home Automation Kit for vanity unit
 category: light
 zigbeemodel: ['5991711', '5991713']
-compatible: [z2m]
+compatible: [z2m] [zha]
 mlink: https://www.villeroy-boch.co.uk/bathroom-and-wellness/products/Subway-3.0-ZigBeeR-Home-Automation-Kit-for-vanity-unit-Rectangle-C5850000.html
 link: https://www.skybad.de/en/villeroy-und-boch-subway-3-0-modul-c5850000-fuer-unterschraenke-funkstandard.html
 ---


### PR DESCRIPTION
compatible with ZHA - manufacturer of hardware: L&S

```
{
  "node_descriptor": "NodeDescriptor(logical_type=<LogicalType.Router: 1>, complex_descriptor_available=0, user_descriptor_available=0, reserved=0, aps_flags=0, frequency_band=<FrequencyBand.Freq2400MHz: 8>, mac_capability_flags=<MACCapabilityFlags.AllocateAddress|RxOnWhenIdle|MainsPowered|FullFunctionDevice: 142>, manufacturer_code=4644, maximum_buffer_size=82, maximum_incoming_transfer_size=82, server_mask=11264, maximum_outgoing_transfer_size=82, descriptor_capability_field=<DescriptorCapability.NONE: 0>, *allocate_address=True, *is_alternate_pan_coordinator=False, *is_coordinator=False, *is_end_device=False, *is_full_function_device=True, *is_mains_powered=True, *is_receiver_on_when_idle=True, *is_router=True, *is_security_capable=False)",
  "endpoints": {
    "1": {
      "profile_id": 260,
      "device_type": "0x010c",
      "in_clusters": [
        "0x0000",
        "0x0003",
        "0x0004",
        "0x0005",
        "0x0006",
        "0x0008",
        "0x0300",
        "0x0b05",
        "0x1000"
      ],
      "out_clusters": [
        "0x0019"
      ]
    },
    "242": {
      "profile_id": 41440,
      "device_type": "0x0066",
      "in_clusters": [
        "0x0021"
      ],
      "out_clusters": [
        "0x0021"
      ]
    }
  },
  "manufacturer": "L&S",
  "model": "5991713",
  "class": "zigpy.device.Device"
}
```