### PR TITLE
Update Ikea_E1745.md

### DIFF
--- a/_zigbee/Ikea_E1745.md
+++ b/_zigbee/Ikea_E1745.md
@@ -17,8 +17,10 @@ EAN: 704.299.13
 ---
 
 ### Pairing
-Pair the sensor by pressing the pair button min. 10 seconds.
-The red light on the front side should flash a few times and the turn off.
-After a few seconds it turns back on and pulsate. When connected, the light turns off. 
+Pair the sensor by pressing the pair button 5 times in a row.
+The red light on the front side should flash a few times, and then the LED will start pulsating and the sensor is in pairing mode.
+When connected, the light turns off.
+
+Some older versions of this device might use a 10-sec-press-and-hold to get into pairing mode.
 ### Reset
 Reset the sensor by pressing the pair button 4 times in a row. Wait till the LED confirms it.


### PR DESCRIPTION
I added the "press 5 times to get in pairing mode" because holding the button for 10 seconds did not work for me. Might be firmware-version dependent? According to this source (https://community.smartthings.com/t/ikea-tradfri-motion-sensor-paring-issues/188209), the 10-sec-press is used to directly pair the sensor to a light bulb, so maybe it should be removed here?!