### PR TITLE
Update Third Reality 3RSP02028BZ to add ZHA compatibility

### DIFF
--- a/_zigbee/Third_Reality_3RSP02028BZ.md
+++ b/_zigbee/Third_Reality_3RSP02028BZ.md
@@ -5,7 +5,7 @@ vendor: Third Reality
 title: Power Meter Plug (Gen 2)
 category: plug
 zigbeemodel: ['3RSP02028BZ']
-compatible: [deconz]
+compatible: [deconz, zha] 
 deconz: 6768
 mlink: 
 link: https://www.amazon.com/dp/B0BPY5D1KC


### PR DESCRIPTION
tested and it does work under Home Assistant ZHA out of the box, switching works as well as the power meter entities