### PR TITLE
Instructions on how to add iHorn/Konke to Z2MQTT

### DIFF
--- a/_zigbee/iHORN_LH-99ZB.md
+++ b/_zigbee/iHORN_LH-99ZB.md
@@ -1,12 +1,12 @@
 ---
 date_added: 2020-11-20
 model: LH-99ZB
-vendor: iHORN/Konke
+vendor: iHORN
 title: Smoke Detector
 category: sensor
 supports: smoke
 zigbeemodel: ['LH05121']
-compatible: [deconz] [Zigbee2MQTT]
+compatible: [deconz, z2m]
 deconz: 3431
 mlink: http://www.ihorn-tech.com/Product/SensorRF/Smoke/ede29afe-ed6e-40bc-baa7-ccc199583cd6.html
 link: 

--- a/_zigbee/iHORN_LH-99ZB.md
+++ b/_zigbee/iHORN_LH-99ZB.md
@@ -1,12 +1,12 @@
 ---
 date_added: 2020-11-20
 model: LH-99ZB
-vendor: iHORN
+vendor: iHORN/Konke
 title: Smoke Detector
 category: sensor
 supports: smoke
 zigbeemodel: ['LH05121']
-compatible: [deconz]
+compatible: [deconz] [Zigbee2MQTT]
 deconz: 3431
 mlink: http://www.ihorn-tech.com/Product/SensorRF/Smoke/ede29afe-ed6e-40bc-baa7-ccc199583cd6.html
 link: 


### PR DESCRIPTION
Add in /config/zigbee2mqtt a file with the (zigbee)model name: lh05121.js to make it compatible with Zigbee2MQTT I am using this in Home Assistant with Zigbee2MQTT, without problems, tested it and received the output i need. Mine is a Konke relabled, but when added it is recognized as iHorn and the physical appearance are the same. You can replace Konke with iHorn in the next part.

Put in the file you made the next part, save it, and reboot after this.

const fz = require('zigbee-herdsman-converters/converters/fromZigbee'); const tz = require('zigbee-herdsman-converters/converters/toZigbee'); const exposes = require('zigbee-herdsman-converters/lib/exposes'); const reporting = require('zigbee-herdsman-converters/lib/reporting'); const extend = require('zigbee-herdsman-converters/lib/extend'); const e = exposes.presets;
const ea = exposes.access;

const definition = {
    zigbeeModel: ['LH05121'], // The model ID from: Device with modelID 'lumi.sens' is not supported.
    model: 'LH05121', // Vendor model number, look on the device for a model number
    vendor: 'Konke', // Vendor of the device (only used for documentation and startup logging)
    description: 'Konke smoke detector', // Description of the device, copy from vendor site. (only used for documentation and startup logging)
    fromZigbee: [fz.ias_smoke_alarm_1],
    toZigbee: [],
    exposes: [e.smoke(), e.battery_low()], // <-- this will define which fields will be exposed in the definition message to configure a front end (e.g. the z2m frontend, Home Assistant, Domoticz)
};

module.exports = definition;