### PR TITLE
Added ZHA compatibility to Ikea bulb with EAN 704.391.96

### DIFF
--- a/_zigbee/Ikea_LED1925G6.md
+++ b/_zigbee/Ikea_LED1925G6.md
@@ -6,7 +6,7 @@ title: Tradfri LED bulb E14 470 lumen, dimmable colour and white, globe opal whi
 category: bulb
 supports: brightness, color
 zigbeemodel: ['TRADFRI bulb E14 CWS 470lm', 'TRADFRI bulb E12 CWS 450lm']
-compatible: [z2m]
+compatible: [z2m, zha]
 mlink: https://www.ikea.com/gb/en/p/tradfri-led-bulb-e14-470-lumen-wireless-dimmable-colour-and-white-spectrum-globe-opal-white-70517636/
 link: 
 link2: 


### PR DESCRIPTION
Ikea Tradfri LED 470lm 704.391.96 is found by Zigbee Home Automation (ZHA) and can be controlled.