### PR TITLE
ZHA support for Aqara H1 single rocker switches

### DIFF
--- a/_zigbee/Aqara_WS-EUK01.md
+++ b/_zigbee/Aqara_WS-EUK01.md
@@ -6,7 +6,7 @@ title: H1 EU Wall Switch (No Neutral, Single Rocker)
 category: switch
 supports: on/off, power outage memory, switch decouple
 zigbeemodel: ['lumi.switch.l1aeu1']
-compatible: [z2m, deconz]
+compatible: [zha, z2m, deconz]
 deconz: 6140
 mlink: https://www.aqara.com/eu/product/smart-wall-switch-h1-no-neutral
 link: https://www.domadoo.fr/en/peripheriques/5726-xiaomi-aqara-interrupteur-mural-intelligent-h1-zigbee-30-sans-neutre-6970504214774.html

--- a/_zigbee/Aqara_WS-EUK03.md
+++ b/_zigbee/Aqara_WS-EUK03.md
@@ -7,7 +7,7 @@ category: switch
 supports: on/off, power outage memory, switch decouple, device temperature, power monitoring 
 action: single, double
 zigbeemodel: ['lumi.switch.n1aeu1']
-compatible: [z2m, deconz, z4d]
+compatible: [zha, z2m, deconz, z4d]
 deconz: 6140
 mlink: https://www.aqara.com/eu/product/smart-wall-switch-h1-with-neutral
 link: https://www.domadoo.fr/en/peripheriques/5728-xiaomi-aqara-interrupteur-mural-intelligent-h1-zigbee-30-avec-neutre-6970504214798.html


### PR DESCRIPTION
I've recently added support for the Aqara H1 single rocker switches (both neutral and "no neutral" versions)

* `WS-EUK03` - https://github.com/zigpy/zha-device-handlers/pull/2385
* `WS-EUK01` - https://github.com/zigpy/zha-device-handlers/pull/2411