### PR TITLE
fix(ui): prevent content layout shift by setting `<img/>` height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 .bundle
+.idea/
 .vscode/
 .sass-cache/
 .jekyll-cache/

--- a/_includes/tablerow.html
+++ b/_includes/tablerow.html
@@ -1,5 +1,5 @@
 <tr>
-  <td class="td-first"><img src="{{ template.url | remove: ".html" | prepend: '/assets/images/devices' | append: '.webp' | processed_path: 'table' }}" alt="{{ template.vendor }} {{ template.model }}" style="max-height:75px;vertical-align: middle;" loading="lazy"></td>
+  <td class="td-first"><img src="{{ template.url | remove: ".html" | prepend: '/assets/images/devices' | append: '.webp' | processed_path: 'table' }}" alt="{{ template.vendor }} {{ template.model }}" height="75" style="max-height:75px;vertical-align: middle;" loading="lazy"></td>
   <td class="td-second"><b><a class="menu" href="{{site.baseurl}}{{ template.url }}">{{ template.vendor }} {{ template.title }}</a></b></td>
   <td>{{ template.model | truncate: 18, '...'}}</td>
   <td class="td-compat">{% if template.compatible contains "zha" %}<img alt="Zigbee Home Automation for Home Assistant" title="Zigbee Home Automation for Home Assistant" src="{{site.baseurl}}/assets/images/zha-icon.png">{% else %} {% endif %}</td>

--- a/_includes/tablerow_nocompatibility.html
+++ b/_includes/tablerow_nocompatibility.html
@@ -1,5 +1,5 @@
 <tr>
-  <td class="td-first"><img src="{{ template.url | remove: ".html" | prepend: '/assets/images/devices' | append: '.webp' | processed_path: 'table' }}" alt="{{ template.vendor }} {{ template.model }}" style="max-height:75px;vertical-align: middle;" loading="lazy"></td>
+  <td class="td-first"><img src="{{ template.url | remove: ".html" | prepend: '/assets/images/devices' | append: '.webp' | processed_path: 'table' }}" alt="{{ template.vendor }} {{ template.model }}" height="75" style="max-height:75px;vertical-align: middle;" loading="lazy"></td>
     <td style="width: 60%;"><b><a class="menu" href="{{site.baseurl}}{{ template.url }}">{{ template.vendor }} {{ template.title }}</a></b></td>
     <td>{{ template.model | truncate: 25, '...'}}</td>
   </tr>


### PR DESCRIPTION
This MR allows browsers to render table items with the right expected height, thus this prevent Content Layout Shift from happening while images are being loaded.

## 🎨  UI

Before:
https://github.com/blakadder/zigbee/assets/9489181/d7865bd6-ca8f-4f5c-883f-1a406876cd88

After:
https://github.com/blakadder/zigbee/assets/9489181/0844f60d-c75b-4a02-aafc-244349874ba0

## 🎲  Misc

Added `.idea/` directory in .gitignore