### PR TITLE
Update Bosch_BSP-FZ2.md

### DIFF
--- a/_zigbee/Bosch_BSP-FZ2.md
+++ b/_zigbee/Bosch_BSP-FZ2.md
@@ -1,14 +1,19 @@
 ---
-model: BSP-FZ2
+model: BSP-FZ2 / BSP-EZ2
 vendor: Bosch
 title: Plug Compact EU 
 category: plug
-zigbeemodel: ['RBSH-SP-ZB-EU']
-compatible: [deconz, z2m]
+zigbeemodel: ['RBSH-SP-ZB-EU', 'RBSH-SP-ZB-FR']
+compatible: [zha, deconz, z2m]
 deconz: 6689
 mlink: https://www.bosch-smarthome.com/at/de/produkte/geraete/zwischenstecker-kompakt/
+mlink2: https://www.bosch-smarthome.com/fr/fr/produits/appareils/prise-connectee-compacte/
 link: https://www.amazon.de/dp/B08QCNVCYV
 link3: https://www.conrad.com/p/zwischenstecker-kompakt-bsp-fz2-bosch-smart-home-in-line-socket-2490147
 link2: https://www.idealo.de/preisvergleich/OffersOfProduct/202107835_-smart-home-bsp-fz2-bosch.html
 link4: 
 ---
+
+## ZHA
+
+Home Assistant Service zha.permit is called (on Developer tools, Services) with its source IEEE and installcode (indicated on the plug). Interview works fine after.


### PR DESCRIPTION
BSP-EZ2 is the same as BSP-FZ2 except for the ground pin (and it seems a close cousin of BSP-GZ2 see https://tt-smarthome.resource.bosch.com/nrt/web/produkt/plug_compact/BSP-QSG_EN_FR_DK_OSS_20200924_web.pdf FR and DK say EZ2/FZ2 and EN GZ2). I used the EZ2 version and connected with ZHA with the IEEE and installcode on the plug (extra description adjusted from Bosch_BTH-RA.html) Not sure if mlink2 is possible, but added it as a mirror of FZ2.