### PR TITLE
Add additional zigbee id for Philips Play Lightbar

### DIFF
--- a/_zigbee/Philips_LCT024.md
+++ b/_zigbee/Philips_LCT024.md
@@ -4,7 +4,7 @@ vendor: Philips
 title: Hue White and Color Ambiance Play Light Bar
 category: bulb
 supports: brightness, colortemp, colorxy
-zigbeemodel: ['LCT024','440400982841', '440400982842']
+zigbeemodel: ['LCT024','440400982841', '440400982842', 'PCM002']
 compatible: [z2m,zha,z4d,deconz]
 z2m: 915005733701
 mlink: https://www.philips-hue.com/en-us/p/hue-white-and-color-ambiance-play-light-bar-single-pack/7820130U7


### PR DESCRIPTION
I found that one of my three Play Lightbars reports a different Zigbee id, PCM002. Endpoints are all the same.