### PR TITLE
Update Zemismart_AM43.md

### DIFF
--- a/_zigbee/Zemismart_AM43.md
+++ b/_zigbee/Zemismart_AM43.md
@@ -15,4 +15,4 @@ link2: https://www.aliexpress.com/item/1005001702490864.html
 link3: 
 ---
 
-Comes under diffent brands such as Zemismart, MoesHouse and Livolo
+Comes under diffent brands such as Zemismart or MoesHouse.


### PR DESCRIPTION
remove livolo because the do not use the TYZS3, instead they has a PIC16LF18456-E/STX microchip installed as a radio module to which a CC2630 board is soldered.

Livolo devices are apparently only working on channel 26 and with 21758D19004B1200 as extended PAN ID.