### PR TITLE
Update Xfinity_XHK1-UE.md

### DIFF
--- a/_zigbee/Xfinity_XHK1-UE.md
+++ b/_zigbee/Xfinity_XHK1-UE.md
@@ -7,7 +7,7 @@ category: remote
 supports: battery, temperature, action
 actions: disarm, arm day zones, identify, arm night zones, arm all zones, invalid code, emergency
 zigbeemodel: ['URC4450BC0-X-R']
-compatible: [z2m, deconz, iob]
+compatible: [z2m, deconz, iob, zha]
 deconz: 6695
 z2m: URC4450BC0-X-R
 mlink: 


### PR DESCRIPTION
Confirmed working w/ ZHA.  However, it doesn't act like you want it to.  Individual key presses are not sent over.  Instead you enter a 4 digit code and then it sends.  HA will see this device as an alarm itself so it'll have it's own armed status to which you can then use in automations with your actual alarm integration.  I chose to send it back and go a different route.  Recommend listening to events to figure out how you can utilize it.