### PR TITLE
Merge _TZ3000_26fmupbb into _TZ3000_oxslvic9

### DIFF
--- a/_zigbee/Tuya_iH-F001.md
+++ b/_zigbee/Tuya_iH-F001.md
@@ -4,10 +4,12 @@ model: iH-F001
 vendor: Tuya
 title: Door/Window Sensor
 category: sensor
+supports: contact, battery
 mlink: 
 link: https://www.aliexpress.com/item/1005003186827400.html
-link2: https://www.amazon.com/dp/B09PVKN3NP
-zigbeemodel: ['TS0203', '_TZ3000_oxslv1c9']
+link2: https://www.aliexpress.com/item/1005003518715880.html
+link3: https://www.amazon.com/dp/B09PVKN3NP
+zigbeemodel: ['TS0203', '_TZ3000_oxslv1c9', '_TZ3000_26fmupbb']
 compatible: [deconz, z2m, zha, ihost]
 z2m: TS0203
 deconz: 6100


### PR DESCRIPTION
Not 100% they're the same device, but they do work the same. Given the original committer didn't include `supports`, I'm judging it supports the same as a standard door sensor (contact/battery), which is the same my _TZ3000_26fmupbb supports (different from other two models, one with tamper and another with pairing issues [which I just submitted via GForm]).