### PR TITLE
Update iluminize_5128.10.md

### DIFF
--- a/_zigbee/iluminize_5128.10.md
+++ b/_zigbee/iluminize_5128.10.md
@@ -6,7 +6,7 @@ title: Curtain Controller
 category: cover
 supports: cover position, cover state
 zigbeemodel: ['5128.10']
-compatible: [z2m, deconz]
+compatible: [zha, z2m, deconz]
 deconz: 7046
 mlink: https://www.iluminize.com/de/shop/led-steuerung/led-controller/product/665-zigbee-3-0-rolladen-aktor-mini-f%C3%BCr-lichtsteuerung,-montage-in-einer-tiefen-schalterdose-schwarz.html
 link: https://www.amazon.de/dp/B097CHM5P3


### PR DESCRIPTION
Confirmed by me as working with ZHA. Often seen as a light (e.g in Hue app), instructions are available in the manual of the actuator. Pressing Calib. 2x will calibrate as roller shutter, 4x as tilt shade. Not possible to invert the direction: Treated as inside shade/cover. Works fine when using setposition 0-100%.