### PR TITLE
Fix product name for Philips Hue LTA001 bulb

### DIFF
--- a/_zigbee/Philips_LTA001.md
+++ b/_zigbee/Philips_LTA001.md
@@ -1,7 +1,7 @@
 ---
 model: LTA001
 vendor: Philips
-title: Hue White E27 with Bluetooth
+title: Hue White Ambiance E27 with Bluetooth
 category: bulb
 supports: brightness, colortemp
 image: /assets/images/devices/Philips_LTA001.jpg


### PR DESCRIPTION
Note that the links may be stale and/or wrong too.