### PR TITLE
Create BTicino_F20T60A.md

### DIFF
--- a/_zigbee/BTicino_F20T60A.md
+++ b/_zigbee/BTicino_F20T60A.md
@@ -1,0 +1,15 @@
+---
+date_added: 2024-01-03
+model: 'F20T60A'
+vendor: BTicino
+title: DIN Power Consumption Module 100-240V 60A
+category: switch
+supports: on/off, power meter, consumption alerts
+zigbeemodel: ['Teleruptor']
+compatible: [zha,deconz,z2m]
+deconz: 3040
+z2m: F20T60A
+mlink: https://catalogue.bticino.com/BTI-F20T60A-EN
+link: https://www.electro-domotique.fr/drivia-netatmo/2195--telerupteur-modulaire-pour-installation-connectee-drivia-with-netatmo-legrand-412170-3414971795587.html
+link2: https://www.amazon.de/-/en/Living-Now-Connect-Din-Meter/dp/B07J1SJ7KS
+---


### PR DESCRIPTION
Very similar to Legrand_412015.
Confirmed working with Home Assistant, trough Sky Connect 1.0 dongle. Worked using channel 11, and did not pair over channel 25. Pairing similar to Legrand