### PR TITLE
Update BTicino_FC80RC.md

### DIFF
--- a/_zigbee/BTicino_FC80RC.md
+++ b/_zigbee/BTicino_FC80RC.md
@@ -7,7 +7,7 @@ category: switch
 type: DIN Relay
 supports: on/off, power meter
 zigbeemodel: ['Teleruptor']
-compatible: [deconz,z2m]
+compatible: ['zha',deconz,z2m]
 deconz: 3040
 z2m: FC80RC
 mlink: https://catalogue.bticino.com/BTI-FC80RC-EN


### PR DESCRIPTION
Confirmed working with Home Assistant using Sky Connect dongle. Managed to pair via channel 11. Previously channel 25 was not able to pair. Pairing very similar to Legrand FC80RC.