### PR TITLE
Update Avatto_TRV06.md

### DIFF
--- a/_zigbee/Avatto_TRV06.md
+++ b/_zigbee/Avatto_TRV06.md
@@ -4,7 +4,7 @@ vendor: Avatto
 model: TRV06
 title: Thermostatic Radiator Valve Controller
 category: hvac
-zigbeemodel: ['TS0601','_TZE200_bvu2wnxz']
+zigbeemodel: ['TS0601','_TZE200_bvu2wnxz', 'TS0601', '_TZE200_hvaxb2tc']
 compatible: [z2m, z4d, deconz, zha]
 quirk: https://github.com/zigpy/zha-device-handlers/issues/1818
 deconz: 6896


### PR DESCRIPTION
I bought this Avatto TRV and the model ID seems to have changed to get it supported in Tasmota ZbBridge.