### PR TITLE
Remove broken comment outputting to webpage

### DIFF
--- a/_includes/tablerow.html
+++ b/_includes/tablerow.html
@@ -8,7 +8,7 @@
   <td class="model">{{ template.model }}</td>
 </tr>
 {% if include.hide_compat %}
-<tr><td></td></tr> {# A hacky way of keeping a table layout more stable #}
+<tr><td></td></tr>
 {% else %}
 <tr>
   <td class="td-compat">


### PR DESCRIPTION
Fixes the zha page that is rendering the broken comment

![image](https://github.com/user-attachments/assets/a9759b60-cc2b-4a8d-9e57-25d15c918350)

Fixes #1273