### PR TITLE
Introduce dark theme

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -3,7 +3,7 @@
 		<img src="{{ "/assets/images/menu.svg" | relative_url }}" class="menu-icon" id="menu" alt="Menu" />
 		<img src="{{ "/assets/images/close.svg" | relative_url }}" class="close-icon" id="close" alt="Close menu" />
 	</div>
-	<div style="text-align: center"><a href="{{ "index.html" | relative_url }}"><img src="{{ "/assets/images/logo.png" | relative_url }}" alt="Logo" /></a></div>
+	<div style="text-align: center" class="sidebar-logo"><a href="{{ "index.html" | relative_url }}"><img src="{{ "/assets/images/logo.png" | relative_url }}" alt="Logo" /></a></div>
 	<!-- {% include search.html %} -->
 	<div class="sidebar-main">
 		{% include nav.html %}

--- a/_layouts/zigbee.html
+++ b/_layouts/zigbee.html
@@ -29,7 +29,7 @@ layout: default
 </div>
 <div class="row">
   <div class="column column-60"> 
-    <img src="{{ page.url | remove: ".html" | prepend: '/assets/images/devices' | append: '.webp' | relative_url }}" alt="{{ page.title }}" style="max-height: 350px; max-width: 400px; margin: 1rem">
+    <img src="{{ page.url | remove: ".html" | prepend: '/assets/images/devices' | append: '.webp' | relative_url }}" alt="{{ page.title }}" style="max-height: 350px; margin: 1rem 0">
   </div>
   <div class="column">
     {% include supports.html %}

--- a/_sass/milligram.scss
+++ b/_sass/milligram.scss
@@ -24,6 +24,11 @@ body {
   font-weight: 300;
   letter-spacing: .01em;
   line-height: 1.5;
+  
+  @media (prefers-color-scheme: dark) {
+    background-color: $background-color-dark-mode;
+    color: $content-color-dark-mode;
+  }
 }
 
 blockquote {
@@ -58,6 +63,11 @@ input[type='submit'] {
   text-decoration: none;
   text-transform: uppercase;
   white-space: nowrap;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: $blue-color-dark-mode;
+    border-color:$blue-color-dark-mode
+  }
 }
 
 .button:focus, .button:hover,
@@ -96,6 +106,11 @@ input[type='submit'][disabled]:focus,
 input[type='submit'][disabled]:hover {
   background-color: #002b80;
   border-color: #002b80;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: $blue-color-dark-mode;
+    border-color:$blue-color-dark-mode;
+  }
 }
 
 .button.button-outline,
@@ -105,6 +120,10 @@ input[type='reset'].button-outline,
 input[type='submit'].button-outline {
   background-color: transparent;
   color: #002b80;
+
+  @media (prefers-color-scheme: dark) {
+    color:$blue-color-dark-mode;
+  }
 }
 
 .button.button-outline:focus, .button.button-outline:hover,
@@ -132,6 +151,10 @@ input[type='submit'].button-outline[disabled]:focus,
 input[type='submit'].button-outline[disabled]:hover {
   border-color: inherit;
   color: #002b80;
+
+  @media (prefers-color-scheme: dark) {
+    color:$blue-color-dark-mode;
+  }
 }
 
 .button.button-clear,
@@ -142,6 +165,10 @@ input[type='submit'].button-clear {
   background-color: transparent;
   border-color: transparent;
   color: #002b80;
+
+  @media (prefers-color-scheme: dark) {
+    color:$blue-color-dark-mode;
+  }
 }
 
 .button.button-clear:focus, .button.button-clear:hover,
@@ -169,12 +196,22 @@ input[type='submit'].button-clear[disabled]:focus,
 input[type='submit'].button-clear[disabled]:hover {
   background-color: slategrey;
   color: #002b80;
+
+  @media (prefers-color-scheme: dark) {
+    color:$blue-color-dark-mode;
+  }
 }
 
 /* Custom color */
 .button-black {
   background-color: black;
   border-color: black;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: $content-color-dark-mode;
+    border-color: $content-color-dark-mode;
+    color: $navigation-background-dark-mode;
+  }
 }
 .button-black.button-clear,
 .button-black.button-outline {
@@ -200,7 +237,7 @@ input[type='submit'].button-clear[disabled]:hover {
 
 .button-red {
   background-color: #EF3453;
-  border-color: white;
+  border-color: transparent;
 }
 .button-red.button-clear,
 .button-red.button-outline {
@@ -286,6 +323,10 @@ textarea:focus,
 select:focus {
   border-color: #002b80;
   outline: 0;
+
+  @media (prefers-color-scheme: dark) {
+    border-color:$blue-color-dark-mode;
+  }
 }
 
 select {
@@ -331,6 +372,7 @@ input[type='radio'] {
   padding: 0;
   position: relative;
   width: 100%;
+  padding-bottom: 5dvh;
 }
 @media (min-width: 40rem) {
   .container {
@@ -453,7 +495,14 @@ input[type='radio'] {
 
 .row .column.column-60 {
   flex: 0 0 60%;
-  max-width: 60%;
+  
+  @media (min-width: 40rem) {
+    max-width: 60%;
+  }
+  
+  img {
+    filter: brightness(0.8) contrast(1.1);
+  }
 }
 
 .row .column.column-66, .row .column.column-67 {
@@ -504,6 +553,10 @@ input[type='radio'] {
 a {
   color: #002b80;
   text-decoration: none;
+
+  @media (prefers-color-scheme: dark) {
+    color:$blue-color-dark-mode;
+  }
 }
 
 a:focus, a:hover {
@@ -584,6 +637,10 @@ th {
   border-bottom: 2px solid #e1e1e1;
   padding: 0.2rem 0.5rem;
   text-align: left;
+
+  @media (prefers-color-scheme: dark) {
+    border-color: $border-color-dark-mode;
+  }
 }
 
 td:first-child,
@@ -607,6 +664,10 @@ th:last-child {
   padding: 0.1rem 0.5rem;
   text-align: left;
   vertical-align: middle;
+
+  @media (prefers-color-scheme: dark) {
+    border-color: $border-color-dark-mode;
+  }
 }
 
 .td-first,
@@ -620,6 +681,10 @@ th:last-child {
   display: block;
   max-height:75px;
   vertical-align: middle;
+
+  @media (prefers-color-scheme: dark) {
+    filter: brightness(0.8) contrast(1.1);
+  }
 }
 
 .td-10,

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -11,10 +11,17 @@ $header-height: 50px;
 
 $link-color: #EF3453;
 
-$sidebar-border: 1px solid rgba(0,0,0,0.07);
+$sidebar-border: 2px solid rgba(0,0,0,0.07);
 $sidebar-color: #364149;
+$sidebar-color-dark-mode: #d1d1d1;
 
 $navigation-background: #fafafa;
+$navigation-background-dark-mode: #101010;
 $navigation-link-color: #EF3453;
 
 $content-color: #333;
+$content-color-dark-mode: #d1d1d1;
+$background-color-dark-mode: #222;
+$border-color-dark-mode: #333;
+
+$blue-color-dark-mode: #719df5;

--- a/assets/css/docs.scss
+++ b/assets/css/docs.scss
@@ -284,3 +284,7 @@ a.menu {
 #nothing-found {
 	display: none;
 }
+
+.compat a {
+	text-wrap: nowrap;
+}

--- a/assets/css/docs.scss
+++ b/assets/css/docs.scss
@@ -20,7 +20,9 @@ html, body {
 }
 
 [src*="tasmota-icon.png"] {
-	filter: invert(1) grayscale(1);
+	@media (prefers-color-scheme: dark) {
+		filter: invert(1) grayscale(1);
+	}
 }
 
 pre {

--- a/assets/css/docs.scss
+++ b/assets/css/docs.scss
@@ -19,6 +19,10 @@ html, body {
 	box-sizing: border-box;
 }
 
+[src*="tasmota-icon.png"] {
+	filter: invert(1) grayscale(1);
+}
+
 pre {
 	margin-bottom: ($base-height * 2) !important;
 }
@@ -64,12 +68,33 @@ a.menu {
 	overflow: hidden;
 	color: $sidebar-color;
 
+	@media (prefers-color-scheme: dark) {
+    color: $sidebar-color-dark-mode;
+		border-color: $border-color-dark-mode;
+  }
+
+	.sidebar-logo {
+		background-color: $navigation-background;
+
+		@media (prefers-color-scheme: dark) {
+			background-color: $navigation-background-dark-mode;
+			
+			img {
+				filter: invert(1) grayscale(1);
+			}
+		}
+	}
+
 	.sidebar-main {
 		height: 100%;
 		background: $navigation-background;
 		padding: $base-height;
 		overflow: auto;
 		padding-bottom: 4em;
+
+		@media (prefers-color-scheme: dark) {
+			background-color: $navigation-background-dark-mode;
+		}
 	}
 
 	.sidebar-mobile {
@@ -78,6 +103,10 @@ a.menu {
 		padding: $base-height;
 		text-align: right;
 		border-bottom: 2px solid #e1e1e1;
+
+		@media (prefers-color-scheme: dark) {
+			border-color: $border-color-dark-mode;
+		}
 
 		.close-icon, .menu-icon {
 			width: 18px;
@@ -93,12 +122,21 @@ a.menu {
 	border-bottom: $sidebar-border;
 	padding: 0 $base-height;
 
+	@media (prefers-color-scheme: dark) {
+    border-color:$border-color-dark-mode;
+  }
+
 	.search-input {
 		border: none;
 		font-size: 0.9em;
 		font-weight: 300;
 		width: 100%;
 		height: 100%;
+		color: $content-color;
+
+		@media (prefers-color-scheme: dark) {
+			color: $content-color-dark-mode;
+		}
 	}
 }
 
@@ -164,6 +202,10 @@ a.menu {
 	color: $content-color;
 	line-height: 1.7;
 	word-wrap: break-word;
+
+	@media (prefers-color-scheme: dark) {
+    color: $content-color-dark-mode;
+  }
 }
 
 .inner {
@@ -210,6 +252,10 @@ a.menu {
 
 			.sidebar-mobile {
 				background: $navigation-background;
+
+				@media (prefers-color-scheme: dark) {
+					background-color: $navigation-background-dark-mode;
+				}
 			}
 		}
 	}

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -57,41 +57,37 @@
 		var imgSrc = `/assets/images/devices${result.href.replace('.html', '')}.webp`;
 		var compatible = Array.isArray(result.compatible) ? result.compatible : [];
 
-		var searchEntry = $(`<tr>
-			<td class="td-first">
-				<img src="${imgSrc}" height="75" alt="${result.vendor} ${result.model}" loading="lazy" />
-			</td>
-			<td class="td-second">
-				<b>
-					<a class="menu" href="${result.href}">
-						${result.vendor} ${result.title}
-					</a>
-				</b>
-			</td>
-			<td>
-				${result.model.length >= 18 ? result.model.substring(0, 15) + '...' : result.model}
-			</td>
-
-			<td class="td-compat">
-				${compatible.includes('zha') ? '<img alt="zha" title="Zigbee Home Automation for Home Assistant" src="/assets/images/zha-icon.png" />' : ''}
-			</td>
-			<td class="td-compat">
-				${compatible.includes('tasmota') || result.category == 'light' || result.category == 'dimmer' ? '<img alt="Tasmota" title="Tasmota" src="/assets/images/tasmota-icon.png" />' : ''}
-			</td>
-			<td class="td-compat">
-				${compatible.includes('z2m') ? '<img alt="Zigbee2MQTT" title="Zigbee2MQTT" src="/assets/images/z2m-icon.png" />' : ''}
-			</td>
-			<td class="td-compat">
-				${compatible.includes('deconz') ? '<img alt="deCONZ" title="deCONZ" src="/assets/images/deconz-icon.png" />' : ''}
-			</td>
-			<td class="td-compat">
-				${compatible.includes('z4d') ? '<img alt="Zigbee for Domoticz" title="Zigbee for Domoticz" src="/assets/images/z4d-icon.png" />' : ''}
-			</td>
-			<td class="td-compat">
-				${compatible.includes('iob') || compatible.includes('z2m') ? '<img alt="ioBroker.zigbee" title="ioBroker.zigbee" src="/assets/images/iobroker-icon.png" />' : ''}
-			</td>
-		</tr>`
-		);
+		var searchEntry = $(`
+			<tr>
+				<td class="td-first" rowspan="4">
+					<img src="${imgSrc}" height="75" alt="${result.vendor} ${result.model}" loading="lazy" />
+				</td>
+			</tr>
+			<tr>
+				<td class="td-second">
+					<b>
+						<a class="menu" href="${result.href}">
+							${result.vendor} ${result.title}
+						</a>
+					</b>
+				</td>
+			</tr>
+			<tr>
+				<td class="model">
+					${result.model.length >= 18 ? result.model.substring(0, 15) + '...' : result.model}
+				</td>
+			</tr>
+			<tr>
+				<td class="td-compat">
+					${compatible.includes('zha') ? '<img alt="zha" title="Zigbee Home Automation for Home Assistant" src="/assets/images/zha-icon.png" />' : ''}
+					${compatible.includes('tasmota') || result.category == 'light' || result.category == 'dimmer' ? '<img alt="Tasmota" title="Tasmota" src="/assets/images/tasmota-icon.png" />' : ''}
+					${compatible.includes('z2m') ? '<img alt="Zigbee2MQTT" title="Zigbee2MQTT" src="/assets/images/z2m-icon.png" />' : ''}
+					${compatible.includes('deconz') ? '<img alt="deCONZ" title="deCONZ" src="/assets/images/deconz-icon.png" />' : ''}
+					${compatible.includes('z4d') ? '<img alt="Zigbee for Domoticz" title="Zigbee for Domoticz" src="/assets/images/z4d-icon.png" />' : ''}
+					${compatible.includes('iob') || compatible.includes('z2m') ? '<img alt="ioBroker.zigbee" title="ioBroker.zigbee" src="/assets/images/iobroker-icon.png" />' : ''}
+				</td>
+			</tr>
+		`);
 
 		return searchEntry
 	}
@@ -109,7 +105,7 @@
 		}
 
 		var fragment = $(document.createDocumentFragment());
-		results.map(function(entry) {
+		results.map(function (entry) {
 			fragment.append(resultEntry(entry))
 		})
 
@@ -157,7 +153,7 @@
 			switch (event.keyCode) {
 				case EscKeyCode:
 					hide()
-				break
+					break
 			}
 		}
 	}

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ title: Zigbee Device Compatibility Repository
         </div>
     </div>
     <div class="row">
-        <div class="column">
+        <div class="column compat">
         <strong><a href="https://www.home-assistant.io/integrations/zha/"><img style="width:20px" alt="Zigbee Home Automation for Home Assistant" src="{{site.baseurl}}/assets/images/zha-icon.png"> ZHA</a>, 
             <a href="https://tasmota.github.io/docs/Zigbee"><img style="width:20px" alt="Tasmota" src="{{site.baseurl}}/assets/images/tasmota-icon.png"> Tasmota</a>, 
             <a href="https://www.zigbee2mqtt.io"><img style="width:20px" alt="Zigbee2MQTT" src="{{site.baseurl}}/assets/images/z2m-icon.png"> Zigbee2MQTT</a>, 


### PR DESCRIPTION
Closes #1277 

---

Besides adding the dark theme, this also:
* Fixes the search results page — presumably broken since #1251
* Avoid wrapping of the compatibility icon+label group

Below are some images that reflect the above:
| Before/Bright     | After/Dark     |
|--------------|--------------|
| ![Screenshot 2025-03-20 at 18 13 45](https://github.com/user-attachments/assets/78232a07-cde5-4abc-8fe3-8ad766641083) | ![Screenshot 2025-03-20 at 18 14 00](https://github.com/user-attachments/assets/a75c5796-8735-48a2-99d6-f4008667b224) |
| ![Screenshot 2025-03-20 at 18 15 39](https://github.com/user-attachments/assets/3f3bb72c-a4fb-4015-badf-ae0275a745b8) | ![Screenshot 2025-03-20 at 18 14 13](https://github.com/user-attachments/assets/9a03299c-163b-495e-9245-9cb51ee163a6) |
| ![Screenshot 2025-03-20 at 18 27 01](https://github.com/user-attachments/assets/28a3f0f5-8daa-4efe-95be-c98a7da28c5f) | ![Screenshot 2025-03-20 at 18 27 15](https://github.com/user-attachments/assets/35c166bb-061c-45bf-88f9-ff8dc0b6fd07) |
| ![Screenshot 2025-03-20 at 18 34 10](https://github.com/user-attachments/assets/f4c022f6-55c7-4986-a6ed-0c1ebff62bf4) | ![Screenshot 2025-03-20 at 18 33 59](https://github.com/user-attachments/assets/ee08ad01-e494-4573-bced-bdf295ba7993) |

Notice that some colors needed to be tweaked for better contrast with a dark background. Created variables for those.
The images on the dark theme have slightly reduced brightness and slightly increased contrast to better fit in a dark environment.

@blakadder Let me know what you think about this.