### PR TITLE
Mark Hive_SIREN001.md as not compatible with z2m

### DIFF
--- a/_zigbee/Hive_SIREN001.md
+++ b/_zigbee/Hive_SIREN001.md
@@ -7,7 +7,7 @@ category: other
 mlink: https://www.hivehome.com/guides/hive-homeshield
 link: https://www.amazon.co.uk/dp/B098NVLNLW
 zigbeemodel: ['SIREN001']
-compatible: [zha, z2m, z4d, tasmota, deconz]
+compatible: [zha, z4d, tasmota, deconz]
 ---
 
 


### PR DESCRIPTION
I'd tried to get a Hive Siren working with z2m, but it doesn't look like it's supported. There's some unmerged [converter code](https://github.com/Koenkk/zigbee2mqtt/issues/11975) but couldn't get it to trigger the siren. I'm not sure that implementation is complete either. So I think it's safer to say it's not supported by z2m at the moment?